### PR TITLE
Subhash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+
+# Large files
+*.mat
+*.pt
+*.pth
+*.tar
+*.zip
+
+# Model checkpoints
+runs/
+trained_checkpoints/
+hough/checkpoint*
+
+# Output / data directories
+masala_chai_50_output/
+masala_chai_output/
+MasalaChai/
+training_data/
+agents_v2_output/
+agents_v2_output_2525/
+agents_v2_output_2525.zip
+agents_v2_test_scaffolding/
+data/
+experiments/
+other_datasets/
+
+# Python cache
+*.pyc
+*.pyc.gz
+__pycache__/
+.ipynb_checkpoints/
+
+# Misc
+*.log
+batch.log
+cursor/
+conda/
+.DS_Store
+.cursor/

--- a/README.md
+++ b/README.md
@@ -1,125 +1,90 @@
 # Masala-CHAI: A Large-Scale SPICE Netlist Dataset for Analog Circuits by Harnessing AI
 
 ## Abstract
-Masala-CHAI is a fully automated framework leveraging large language models (LLMs) to generate Simulation Programs with Integrated Circuit Emphasis (SPICE) netlists. It addresses a long-standing challenge in circuit design automation: automating netlist generation for analog circuits. Automating this workflow could accelerate the creation of fine-tuned LLMs for analog circuit design and verification. In this work, we identify key challenges in automated netlist generation and evaluate multimodal capabilities of state-of-the-art LLMs, particularly GPT-4, in addressing them. We propose a three-step workflow to overcome existing limitations: labeling analog circuits, prompt tuning, and netlist verification. This approach enables end-to-end SPICE netlist generation from circuit schematic images, tackling the persistent challenge of accurate netlist generation. We utilize Masala-CHAI to collect a corpus of 7,500 schematics that span varying complexities in 10 textbooks and benchmark various open source and proprietary LLMs. Models fine-tuned on Masala-CHAI when used in LLM-agentic frameworks such as AnalogCoder achieve a notable 46% improvement in Pass@1 scores. We open-source our dataset and code for community-driven development.
+Masala-CHAI is a fully automated framework leveraging large language models (LLMs) to generate Simulation Programs with Integrated Circuit Emphasis (SPICE) netlists. It addresses a long-standing challenge in circuit design automation: automating netlist generation for analog circuits. Automating this workflow could accelerate the creation of fine-tuned LLMs for analog circuit design and verification. In this work, we identify key challenges in automated netlist generation and evaluate multimodal capabilities of state-of-the-art LLMs, particularly GPT-4, in addressing them. We propose a three-step workflow to overcome existing limitations: labeling analog circuits, prompt tuning, and netlist verification. This approach enables end-to-end SPICE netlist generation from circuit schematic images, tackling the persistent challenge of accurate netlist generation. We utilize Masala-CHAI to collect a corpus of 7,500 schematics that span varying complexities in 10 textbooks and benchmark various open source and proprietary LLMs. Models fine-tuned on Masala-CHAI when used in LLM-agentic frameworks such as AnalogCoder achieve a notable **46% improvement in Pass@1 scores**. We open-source our dataset and code for community-driven development.
 
-For full paper, use this link: https://arxiv.org/abs/2411.14299
+Full paper: https://arxiv.org/abs/2411.14299
 
 > [!NOTE]
-> **December 24, 2025**: A new version of the framework and dataset is being prepared that includes a validation LLM agent to verify the accuracy of the generated netlists. Stay tuned!
+> **May 2026**: V2 multi-agent pipeline now available with ngspice simulation validation and iterative judge feedback. See [Pipeline V2](#pipeline-v2-multi-agent-with-judge) below.
 
+---
 
-## File and Folder Description
+## Setup
 
-- `./hough/` : Folder containing scripts to use Hough Transform for net detection. Due to large size of the files, download the hough/ content from this Google Drive link: https://drive.google.com/file/d/1mTwWWSMsYwhJW-GfKKVm21Lm5lVtMJ1y/view?usp=sharing
-- `./models/` : Folder containing scripts for YOLOv8-based circuit component detection.
-- `./sample-images/` : Folder containing sample images to run the Auto-SPICE netlist generator.
-- `./trained_checkpoints/` : Contains checkpoint file for YOLOv8 model after training.
-- `./utils/` : Supporting scripts for various components of the Auto-SPICE pipeline.
-- `./Dataset/` : Folder containing dataset of the images with schematics.
-     - This contains images from AMSNet repo as well.
-     - Arranged across different data_* folder depending upon their sources.
-- `main.py` : Main script that runs the entire pipeline.
-- `run.py` : Script to be called for generating netlists for sample images.
-- `environment.yml`: Requirements file for creating conda environment
-- `visualize.ipynb`: Jupyter notebook for visualizing output of Autospice for a given circuit diagram
+```bash
+git clone <repository_url>
+cd repository_name
+conda env create -f environment.yml
+conda activate autospice_env
+pip install ngspice
+```
 
-## Steps to Run the Framework
+Download Hough Transform model: https://drive.google.com/file/d/1mTwWWSMsYwhJW-GfKKVm21Lm5lVtMJ1y/view?usp=sharing — extract to `./hough/`
 
-1. **Clone the repository and navigate into the repository:**
+---
 
-   ```bash
-   git clone <repository_url>
-   cd <repository_name>
-2. **Create a Conda environment:**
+## Pipeline V1 (Original)
 
-   ```bash
-   conda env create -f environment.yml
-3. **Activate the Conda environment:**
-	```bash
-   conda activate autospice_env
-4. **Add sample images:**
-	Place your sample images in the `./sample-images/` folder.
-5. **Run the pipeline:**
-	```bash
-	python run.py --src ./sample-images/ --tgt ./sample-output --api_key <openai_api_key>
-	where - 
-	- `--src` : Directory path to the sample images.
-	- `--tgt` : Output directory path for the generated netlists.
-	- `--api_key` : Your OpenAI API key for using GPT-4
+```bash
+python main.py \
+  --src ./data/sample-images/ \
+  --tgt ./sample-output \
+  --api_key <openai_api_key>
+```
 
-## Schematic Caption Generation using GPT-4o
+**Outputs per image:** `scanned_circuit.png`, `detected_components.png`, `component_removed_circuit.png`, `nodes_terminals.png`, `rebuilt_circuit.png`, `sample_statistics.json`, `spice.txt`
 
-1. **Extract and Annotate Schematics:**
-    - Use the `utils/extract_page.py` script to process textbook PDFs and automatically detect schematic images.
-    - This script will crop and annotate the images, saving them into separate folders in the same directory as the original PDF.
-    - The cropped images can be used to run the Masala-CHAI framework.
+---
 
-    ```bash
-    python utils/extract_page.py <path_to_your_pdf> 
-    ```
-    **Notes**:
-    - `<path_to_your_pdf>` is the full path to the PDF file containing schematics.
-    - `./annotation_data.json` is the json file which contains all information about the annotated pages, bounding boxes, etc.
-    - `./cropped_images/` is where the cropped circuit diagrams are saved
+## Pipeline V2 (Multi-Agent with Judge)
 
-2. **Generate Captions for Annotated Images:**
-    - Please rename `./annotation_data.json` to `./annotation_data_pdfname.json`. You will also need an OpenAI API Key for the next step.
-    - Once the images are annotated, you can run the `utils/caption-generator.py` script to utilize GPT-4o for generating captions.
-    - The captions are saved in a folder alongside the annotated images.
+V2 replaces the single LLM pass with three specialized agents and an ngspice simulation check:
 
-    ```bash
-    python utils/caption-generator.py <path_to_your_pdf> 
-    ```
-    **Notes**:
-    - `--./descriptions_short_<pdfname>`: The path to the folder containing generated captions for all circuit diagrams
-    - The descriptons can be paired with their corresponding SPICE netlist generated by the framework to fine-tune LLMs
+- **Agent 1** — validates YOLO detections, corrects types, flags missed components
+- **Agent 2** — traces connectivity visually, generates SPICE netlist, runs ngspice
+- **Judge** — verifies component completeness, checks simulation, sends feedback to agents on failure (up to 2 revisions)
 
+**Run:**
+```bash
+export OPENAI_API_KEY='your-key'
 
-## Descriptions of outputs obtained from Masala-CHAI framework
+# Single image
+python -m agents_v2.run --image data/sample-images/330.jpg --output agents_v2_output/
 
-For each sample circuit, the output consists of a number of files to help the user understand the output of various components in the pipeline:
+# Batch
+python -m agents_v2.run --batch data/sample-images/ --output results/ --parallel --workers 4
+```
 
-1. **scanned_circuit.png**: Copy of the original circuit diagram.
-2. **detected_components.png**, **component_removed_circuit.png**, **components_description.txt**: Output of the YOLOv8 component detection module:
-   - `detected_components.png`: Components marked with bounding boxes.
-   - `component_removed_circuit.png`: Components replaced with white spaces.
-   - `components_description.txt`: Text file containing the description of the detected components.
-3. **nodes_terminals.png**, **connections_descriptions.txt**, **nodes_description.txt**: Detected nodes in the circuit using Hough Transform:
-   - `nodes_terminals.png`: Detected nodes in the circuit.
-   - `connections_descriptions.txt`: Text file containing descriptions of various connections.
-   - `nodes_description.txt`: Text file containing the description of various nodes in the circuit.
-4. **text_and_comp_removed_circuit.png**: Original circuit diagram after removing all text content and detected circuit components.
-5. **rebuilt_circuit.png**: Original circuit diagram overlaid with components and nodes.
-6. **original_withComponentsAndLineLabels.png**, **original_withLineLabels.png**: Used for better visualization of the model output.
-7. **sample_statistics.json**: Dictionary describing types of components in the circuit, along with node and net information.
-8. **spice.txt**: Final generated SPICE netlist for the circuit diagram.
+**V2 outputs** (in `agents_v2_output/agents/<name>/`): `.sp` netlist, `_simulation.log`, `_judge_result.json`, `_validated_components.json`, `_llm_flow.md`
 
-We also provide a helpful visualization of model output using a jupyer notebook: `visualize.ipynb`
+---
 
-## Dataset Link
+## Schematic Caption Generation
 
-We utilize Masala-CHAI to create the largest open-sourced corpus for parallel circuit descriptions and SPICE netlists. You can download the dataset here: https://drive.google.com/file/d/1aNC-8mye_Pbw9nYS0cmN2ggUaThJHUP2/view?usp=sharing
+```bash
+python utils/extract_page.py <path_to_pdf>       # extract schematics from PDF
+python utils/caption-generator.py <path_to_pdf>  # generate GPT-4o captions
+```
 
-## Inference with Finetuned Code Llama 70B
+---
 
-Please refer to `./codellama-endpoints/` for detailed instructions and checkpoints.
+## Dataset
 
-## Annotated dataset from Analog-Genie
+Download (7,500 schematics, 10 textbooks): https://drive.google.com/file/d/1aNC-8mye_Pbw9nYS0cmN2ggUaThJHUP2/view?usp=sharing
 
-AnalogGenie (https://github.com/xz-group/AnalogGenie/tree/main) provides a new dataset with SPICE netlists but does not include circuit description captions for fine-tuning LLMs. We used our Masala-CHAI framework on their dataset to generate captions for the respective schematics. You can find this dataset here: `./analoggenie.jsonl`
+---
 
-## Citing Masala-CHAI
-
-If you use Masala-CHAI or the shared dataset in your research, please cite using the following BibTeX entry:
+## Citation
 
 ```bibtex
 @misc{bhandari2025masalachailargescalespicenetlist,
-      title={Masala-CHAI: A Large-Scale SPICE Netlist Dataset for Analog Circuits by Harnessing AI}, 
+      title={Masala-CHAI: A Large-Scale SPICE Netlist Dataset for Analog Circuits by Harnessing AI},
       author={Jitendra Bhandari and Vineet Bhat and Yuheng He and Hamed Rahmani and Siddharth Garg and Ramesh Karri},
       year={2025},
       eprint={2411.14299},
       archivePrefix={arXiv},
       primaryClass={cs.AR},
-      url={https://arxiv.org/abs/2411.14299}, 
+      url={https://arxiv.org/abs/2411.14299},
 }
+```

--- a/agents_v2/__init__.py
+++ b/agents_v2/__init__.py
@@ -1,0 +1,22 @@
+"""
+Agents V2: Refinement-Based Pipeline with Training Data Collection
+
+Architecture:
+- Agent 1: Component Refinement (VLM)
+- Agent 2: Connectivity Refinement (VLM)  
+- Agent 3: Netlist Generation (LLM)
+- LLM-as-Judge: Cross-Validation (Mandatory)
+
+Features:
+- ReAct-style agents with error context propagation
+- Graceful continuation on failure with NEEDS_REVIEW flags
+- Comprehensive training data collection for curriculum learning
+- Multi-head YOLO training data export
+"""
+
+from .workflow import run_pipeline, RefinementPipeline
+from .config import PipelineConfig, ModelConfig
+
+__version__ = "2.0.0"
+__all__ = ["run_pipeline", "RefinementPipeline", "PipelineConfig", "ModelConfig"]
+

--- a/agents_v2/agents/__init__.py
+++ b/agents_v2/agents/__init__.py
@@ -1,0 +1,18 @@
+"""
+Agents for V2 Pipeline
+"""
+
+from .base_agent import BaseReActAgent
+from .component_agent import ComponentRefinementAgent
+from .connectivity_agent import ConnectivityRefinementAgent
+from .netlist_agent import NetlistGenerationAgent
+from .judge_agent import LLMJudge
+
+__all__ = [
+    "BaseReActAgent",
+    "ComponentRefinementAgent",
+    "ConnectivityRefinementAgent",
+    "NetlistGenerationAgent",
+    "LLMJudge"
+]
+

--- a/agents_v2/agents/base_agent.py
+++ b/agents_v2/agents/base_agent.py
@@ -1,0 +1,390 @@
+"""
+Base ReAct Agent with Error Context Propagation
+
+This implements the core ReAct (Reason + Act) loop with:
+1. Error context from previous iterations
+2. Metric-based evaluation
+3. Graceful continuation on failure
+4. Training data collection
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any, Tuple
+import time
+import json
+import base64
+from io import BytesIO
+from PIL import Image
+
+import os
+from openai import OpenAI
+
+from ..config import PipelineConfig, QualityTier
+from ..models.output import StageResult, IterationRecord
+from ..models.training_data import RefinementDeltas, ChangeLogEntry
+
+
+@dataclass
+class AgentContext:
+    """Context passed between iterations"""
+    
+    # Input data
+    original_input: Dict[str, Any] = field(default_factory=dict)
+    
+    # Previous iteration output
+    previous_output: Optional[Dict] = None
+    
+    # Metrics from previous iteration
+    previous_metrics: Dict[str, float] = field(default_factory=dict)
+    passed_metrics: List[str] = field(default_factory=list)
+    failed_metrics: List[str] = field(default_factory=list)
+    
+    # Specific errors to fix
+    errors: List[str] = field(default_factory=list)
+    
+    # Actionable feedback
+    feedback: str = ""
+    
+    # Upstream quality flags
+    upstream_needs_review: bool = False
+    upstream_confidence: float = 1.0
+
+
+class BaseReActAgent(ABC):
+    """
+    Base class for ReAct-style agents with error context propagation.
+    
+    Each iteration:
+    1. THINK: Analyze input + previous errors
+    2. ACT: Perform the task
+    3. OBSERVE: Evaluate metrics
+    4. REFLECT: If failed, build error context for next iteration
+    """
+    
+    def __init__(
+        self,
+        agent_name: str,
+        model: str,
+        config: PipelineConfig,
+        requires_vision: bool = True
+    ):
+        self.agent_name = agent_name
+        self.model = model
+        self.config = config
+        self.requires_vision = requires_vision
+        
+        # Initialize OpenAI client
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OpenAI API key not found. Set OPENAI_API_KEY environment variable.\n"
+                "Example: export OPENAI_API_KEY='your-api-key'"
+            )
+        self.client = OpenAI(api_key=api_key)
+        
+        # Iteration tracking
+        self.current_iteration = 0
+        self.iteration_history: List[IterationRecord] = []
+        self.best_output: Optional[Dict] = None
+        self.best_score: float = 0.0
+        self.best_iteration: int = 0
+        
+        # Refinement tracking
+        self.refinement_deltas = RefinementDeltas()
+        
+        # Token tracking
+        self.total_tokens = 0
+    
+    @abstractmethod
+    def get_max_iterations(self) -> int:
+        """Get max iterations for this agent"""
+        pass
+    
+    @abstractmethod
+    def get_pass_threshold(self) -> float:
+        """Get pass threshold for this agent"""
+        pass
+    
+    @abstractmethod
+    def get_min_viable_threshold(self) -> float:
+        """Get minimum viable threshold"""
+        pass
+    
+    @abstractmethod
+    def get_system_prompt(self) -> str:
+        """Get the system prompt for this agent"""
+        pass
+    
+    @abstractmethod
+    def build_user_prompt(self, context: AgentContext, iteration: int) -> str:
+        """Build the user prompt including error context"""
+        pass
+    
+    @abstractmethod
+    def parse_response(self, response: str, context: AgentContext) -> Dict[str, Any]:
+        """Parse the LLM response into structured output"""
+        pass
+    
+    @abstractmethod
+    def evaluate_metrics(self, output: Dict[str, Any], context: AgentContext) -> Dict[str, float]:
+        """Evaluate the output and return metrics"""
+        pass
+    
+    @abstractmethod
+    def build_error_context(
+        self,
+        output: Dict[str, Any],
+        metrics: Dict[str, float],
+        context: AgentContext
+    ) -> AgentContext:
+        """Build error context for next iteration"""
+        pass
+    
+    def run(
+        self,
+        input_data: Dict[str, Any],
+        images: Optional[List[Image.Image]] = None,
+        upstream_context: Optional[Dict] = None
+    ) -> Tuple[Dict[str, Any], StageResult]:
+        """
+        Run the agent with ReAct loop.
+        
+        Returns:
+            Tuple of (best_output, stage_result)
+        """
+        start_time = time.time()
+        
+        # Initialize context
+        context = AgentContext(
+            original_input=input_data,
+            upstream_needs_review=upstream_context.get("needs_review", False) if upstream_context else False,
+            upstream_confidence=upstream_context.get("confidence", 1.0) if upstream_context else 1.0
+        )
+        
+        # Initialize stage result
+        stage_result = StageResult(
+            stage_name=self.agent_name,
+            model_used=self.model
+        )
+        
+        max_iterations = self.get_max_iterations()
+        
+        for iteration in range(1, max_iterations + 1):
+            self.current_iteration = iteration
+            iter_start = time.time()
+            
+            if self.config.verbose:
+                print(f"\n{'='*60}")
+                print(f"  {self.agent_name} - Iteration {iteration}/{max_iterations}")
+                print(f"{'='*60}")
+            
+            # Build prompt with error context
+            user_prompt = self.build_user_prompt(context, iteration)
+            
+            # Call LLM
+            try:
+                response, tokens = self._call_llm(
+                    self.get_system_prompt(),
+                    user_prompt,
+                    images if self.requires_vision else None
+                )
+                self.total_tokens += tokens
+            except Exception as e:
+                print(f"  ERROR: LLM call failed: {e}")
+                context.errors.append(f"LLM call failed: {str(e)}")
+                continue
+            
+            # Parse response
+            try:
+                output = self.parse_response(response, context)
+            except Exception as e:
+                print(f"  ERROR: Failed to parse response: {e}")
+                context.errors.append(f"Parse failed: {str(e)}")
+                continue
+            
+            # Evaluate metrics
+            metrics = self.evaluate_metrics(output, context)
+            score = self._compute_score(metrics)
+            
+            # Check which metrics passed/failed
+            passed_metrics = []
+            failed_metrics = []
+            for metric, value in metrics.items():
+                target = self._get_metric_target(metric)
+                if value >= target:
+                    passed_metrics.append(metric)
+                else:
+                    failed_metrics.append(metric)
+            
+            # Record iteration
+            iter_record = IterationRecord(
+                iteration_number=iteration,
+                metrics=metrics,
+                score=score,
+                passed=score >= self.get_pass_threshold(),
+                actions_taken=output.get("actions", []),
+                errors_found=failed_metrics,
+                duration_seconds=time.time() - iter_start,
+                tokens_used=tokens
+            )
+            self.iteration_history.append(iter_record)
+            stage_result.add_iteration(iter_record)
+            
+            if self.config.verbose:
+                print(f"\n  Metrics:")
+                for m, v in metrics.items():
+                    status = "✓" if m in passed_metrics else "✗"
+                    print(f"    {m}: {v:.3f} {status}")
+                print(f"\n  Score: {score:.3f} (target: {self.get_pass_threshold():.2f})")
+            
+            # Update best if improved
+            if score > self.best_score:
+                self.best_score = score
+                self.best_output = output
+                self.best_iteration = iteration
+                if self.config.verbose:
+                    print(f"  ✓ New best score!")
+            
+            # Check if passed
+            if score >= self.get_pass_threshold():
+                if self.config.verbose:
+                    print(f"\n  ✓ PASSED - All metrics satisfied")
+                break
+            
+            # Build error context for next iteration
+            if iteration < max_iterations:
+                context = self.build_error_context(output, metrics, context)
+                context.previous_output = output
+                context.previous_metrics = metrics
+                context.passed_metrics = passed_metrics
+                context.failed_metrics = failed_metrics
+                
+                if self.config.verbose:
+                    print(f"\n  ✗ FAILED - Preparing error context for next iteration")
+                    print(f"  Failed metrics: {failed_metrics}")
+        
+        # Finalize stage result
+        stage_result.final_metrics = metrics if 'metrics' in dir() else {}
+        stage_result.final_score = self.best_score
+        stage_result.passed = self.best_score >= self.get_pass_threshold()
+        stage_result.best_output = self.best_output
+        stage_result.total_duration = time.time() - start_time
+        stage_result.total_tokens = self.total_tokens
+        
+        # Determine if needs review
+        if self.best_score < self.get_min_viable_threshold():
+            stage_result.needs_review = True
+            stage_result.review_reasons.append(
+                f"Score {self.best_score:.2f} below minimum viable {self.get_min_viable_threshold()}"
+            )
+        elif self.best_score < self.get_pass_threshold():
+            stage_result.needs_review = True
+            stage_result.review_reasons.append(
+                f"Score {self.best_score:.2f} below pass threshold {self.get_pass_threshold()}"
+            )
+        
+        if self.config.verbose:
+            print(f"\n  {'='*50}")
+            print(f"  {self.agent_name} COMPLETE")
+            print(f"  Best Score: {self.best_score:.3f} (iteration {self.best_iteration})")
+            print(f"  Passed: {stage_result.passed}")
+            print(f"  Needs Review: {stage_result.needs_review}")
+            print(f"  {'='*50}")
+        
+        return self.best_output or {}, stage_result
+    
+    def _call_llm(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        images: Optional[List[Image.Image]] = None
+    ) -> Tuple[str, int]:
+        """Call the LLM with optional images"""
+        
+        messages = [
+            {"role": "system", "content": system_prompt}
+        ]
+        
+        # Build user message with images
+        if images and self.requires_vision:
+            content = [{"type": "text", "text": user_prompt}]
+            for img in images:
+                # Cap at 1024px longest side — sufficient for vision, avoids token explosion
+                _img = img.copy()
+                if max(_img.size) > 1024:
+                    _img.thumbnail((1024, 1024))
+                # Convert to RGB for JPEG (drops alpha channel if present)
+                if _img.mode in ("RGBA", "P"):
+                    _img = _img.convert("RGB")
+                buffered = BytesIO()
+                _img.save(buffered, format="JPEG", quality=85)
+                img_base64 = base64.b64encode(buffered.getvalue()).decode()
+                content.append({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{img_base64}",
+                        "detail": "high"
+                    }
+                })
+            messages.append({"role": "user", "content": content})
+        else:
+            messages.append({"role": "user", "content": user_prompt})
+        
+        # Call API - handle different parameter names for different models
+        # Newer models (o1, gpt-5.x) use max_completion_tokens
+        # Older models (gpt-4o, gpt-4) use max_tokens
+        api_params = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0.2
+        }
+        
+        # Check if model uses new API format
+        if any(x in self.model.lower() for x in ["o1", "o3", "o4", "gpt-5", "5.2"]):
+            api_params["max_completion_tokens"] = 4096
+        else:
+            api_params["max_tokens"] = 4096
+        
+        response = self.client.chat.completions.create(**api_params)
+        
+        tokens = response.usage.total_tokens if response.usage else 0
+        content = response.choices[0].message.content or ""
+        
+        return content, tokens
+    
+    def _compute_score(self, metrics: Dict[str, float]) -> float:
+        """Compute weighted score from metrics"""
+        weights = self._get_metric_weights()
+        total_weight = sum(weights.get(m, 1.0) for m in metrics)
+        score = sum(
+            metrics[m] * weights.get(m, 1.0)
+            for m in metrics
+        ) / total_weight if total_weight > 0 else 0.0
+        return score
+    
+    def _get_metric_weights(self) -> Dict[str, float]:
+        """Get metric weights - override in subclass"""
+        return {}
+    
+    def _get_metric_target(self, metric: str) -> float:
+        """Get target value for a metric - override in subclass"""
+        return 0.8
+    
+    def log_change(
+        self,
+        action: str,
+        target_type: str,
+        target_id: str,
+        **kwargs
+    ):
+        """Log a refinement change"""
+        self.refinement_deltas.add_change(
+            agent=self.agent_name,
+            iteration=self.current_iteration,
+            action=action,
+            target_type=target_type,
+            target_id=target_id,
+            **kwargs
+        )
+

--- a/agents_v2/agents/component_agent.py
+++ b/agents_v2/agents/component_agent.py
@@ -1,0 +1,341 @@
+"""
+Component Refinement Agent (Agent 1) - SIMPLIFIED
+
+LLM only validates YOLO detections. No coordinate generation.
+All spatial data comes from YOLO.
+"""
+
+import re
+import json
+from typing import Dict, Any, List
+
+from .base_agent import BaseReActAgent, AgentContext
+from ..models.components import ComponentInfo, BoundingBox, Point, TerminalInfo
+from ..config import PipelineConfig
+
+
+class ComponentRefinementAgent(BaseReActAgent):
+    """
+    Agent 1: Component Validation
+    
+    LLM ONLY outputs: which YOLO detections to keep/reject
+    ALL coordinates come from YOLO, never from LLM
+    """
+    
+    def __init__(self, model: str, config: PipelineConfig):
+        super().__init__(
+            agent_name="component_refinement",
+            model=model,
+            config=config,
+            requires_vision=True
+        )
+    
+    def get_max_iterations(self) -> int:
+        return 2
+    
+    def get_pass_threshold(self) -> float:
+        return 0.70
+    
+    def get_min_viable_threshold(self) -> float:
+        return 0.50
+    
+    def get_system_prompt(self) -> str:
+        return """You validate YOLO detections from circuit schematics.
+
+For each detection:
+- "keep": true/false - is this a real component?
+- "type": the CORRECT component type (may differ from YOLO's guess)
+- "corrected": true if you changed the type from YOLO's classification
+
+PAY ATTENTION TO CONFIDENCE:
+- High confidence (>0.8): YOLO is likely correct, verify type
+- Medium confidence (0.5-0.8): Check carefully, may be misclassified
+- Low confidence (<0.5): YOLO is uncertain - use your judgment to correct
+
+Common misclassifications:
+- MOSFET vs Capacitor (similar shapes)
+- Resistor vs Inductor (zigzag vs coil)
+- Ground vs generic symbol
+- Current_Source vs Voltage_Source
+
+Output JSON:
+```json
+{
+  "decisions": [
+    {"idx": 0, "keep": true, "type": "Resistor", "corrected": false},
+    {"idx": 1, "keep": true, "type": "NMOS", "corrected": true, "yolo_said": "Capacitor", "reason": "shape is clearly a MOSFET"},
+    {"idx": 2, "keep": false, "reason": "text label, not a component"},
+    {"idx": 3, "keep": true, "type": "Ground", "corrected": false}
+  ],
+  "missed": [
+    {"type": "Ground", "location": "bottom center", "reason": "visible ground symbol not detected"}
+  ]
+}
+```
+
+DO NOT generate coordinates. Just validate/correct types."""
+    
+    def build_user_prompt(self, context: AgentContext, iteration: int) -> str:
+        yolo_detections = context.original_input.get("yolo_detections", [])
+        
+        prompt = f"Validate these {len(yolo_detections)} YOLO detections:\n\n"
+        
+        for i, det in enumerate(yolo_detections):
+            conf = det.get('confidence', 0)
+            cls = det.get('class', '?')
+            
+            # Confidence indicator
+            if conf >= 0.8:
+                conf_indicator = "✓ HIGH"
+            elif conf >= 0.5:
+                conf_indicator = "⚠ MEDIUM"
+            else:
+                conf_indicator = "❌ LOW - likely wrong"
+            
+            prompt += f"[{i}] {cls} (conf: {conf:.2f}) {conf_indicator}\n"
+        
+        if iteration > 1 and context.errors:
+            prompt += f"\n\nFix these issues:\n"
+            for e in context.errors:
+                prompt += f"- {e}\n"
+        
+        prompt += "\n\nFor LOW confidence detections, check if the type is correct and correct if needed."
+        
+        return prompt
+    
+    def parse_response(self, response: str, context: AgentContext) -> Dict[str, Any]:
+        """Parse LLM decisions and build components from YOLO"""
+        
+        yolo_detections = context.original_input.get("yolo_detections", [])
+        
+        # Try to extract JSON object first (new format with missed), then array
+        decisions = []
+        missed = []
+        
+        json_obj_match = re.search(r'\{[\s\S]*\}', response)
+        if json_obj_match:
+            try:
+                data = json.loads(json_obj_match.group(0))
+                decisions = data.get("decisions", [])
+                missed = data.get("missed", [])
+            except:
+                pass
+        
+        # Fallback to array format
+        if not decisions:
+            json_arr_match = re.search(r'\[[\s\S]*\]', response)
+            if json_arr_match:
+                try:
+                    decisions = json.loads(json_arr_match.group(0))
+                except:
+                    decisions = []
+        
+        # If no valid decisions, just keep all YOLO detections
+        if not decisions:
+            print(f"    No valid decisions, keeping all {len(yolo_detections)} YOLO detections")
+            decisions = [{"idx": i, "keep": True, "type": d.get("class", "Unknown")} 
+                        for i, d in enumerate(yolo_detections)]
+        
+        # Build components from YOLO data + LLM decisions
+        components = []
+        rejected = []
+        corrected = []
+        
+        for dec in decisions:
+            idx = dec.get("idx", dec.get("index", -1))
+            keep = dec.get("keep", True)
+            
+            if idx < 0 or idx >= len(yolo_detections):
+                continue
+            
+            yolo = yolo_detections[idx]
+            yolo_type = yolo.get("class", "Unknown")
+            yolo_conf = yolo.get("confidence", 0)
+            
+            if not keep:
+                rejected.append({
+                    "idx": idx, 
+                    "reason": dec.get("reason", "rejected"),
+                    "yolo_type": yolo_type,
+                    "yolo_conf": yolo_conf
+                })
+                continue
+            
+            # Build component from YOLO coordinates
+            bbox = BoundingBox(
+                x_min=int(yolo.get("x_min", 0)),
+                y_min=int(yolo.get("y_min", 0)),
+                x_max=int(yolo.get("x_max", 0)),
+                y_max=int(yolo.get("y_max", 0))
+            )
+            
+            # Check if type was corrected
+            comp_type = dec.get("type", yolo_type)
+            was_corrected = dec.get("corrected", False) or (comp_type != yolo_type)
+            
+            if was_corrected:
+                corrected.append({
+                    "idx": idx,
+                    "yolo_type": yolo_type,
+                    "corrected_type": comp_type,
+                    "yolo_conf": yolo_conf,
+                    "reason": dec.get("reason", "type corrected by LLM")
+                })
+                print(f"    🔄 Corrected [{idx}]: {yolo_type} → {comp_type} (was {yolo_conf:.2f} conf)")
+            
+            terminals = self._auto_terminals(comp_type, bbox)
+            
+            comp = ComponentInfo(
+                id=f"{self._prefix(comp_type)}{len(components)+1}",
+                type=comp_type,
+                bbox=bbox,
+                center=bbox.center,
+                orientation="vertical" if bbox.height > bbox.width else "horizontal",
+                terminals=terminals,
+                source="yolo_corrected" if was_corrected else "yolo",
+                original_detection=yolo,
+                confidence=float(yolo_conf),
+                refinement_notes=dec.get("reason", "") if was_corrected else ""
+            )
+            components.append(comp)
+        
+        # Log missed components (flagged by LLM but no coordinates)
+        if missed:
+            print(f"    ⚠ LLM flagged {len(missed)} potentially missed components:")
+            for m in missed:
+                print(f"      - {m.get('type', '?')} at {m.get('location', '?')}: {m.get('reason', '')}")
+        
+        # Summary
+        print(f"    ✓ Kept {len(components)}, rejected {len(rejected)}, corrected {len(corrected)}, flagged {len(missed)} missed")
+        
+        return {
+            "components": components,
+            "rejected": rejected,
+            "corrected": corrected,  # Type corrections made by LLM
+            "missed_flagged": missed,  # Components LLM thinks YOLO missed
+            "actions": [
+                f"Kept {len(components)} components",
+                f"Rejected {len(rejected)} false positives",
+                f"Corrected {len(corrected)} misclassifications",
+                f"Flagged {len(missed)} potentially missed"
+            ]
+        }
+    
+    def _prefix(self, comp_type: str) -> str:
+        prefixes = {"Resistor": "R", "Capacitor": "C", "NMOS": "M", "PMOS": "M", 
+                   "MOSFET": "M", "Ground": "GND", "Current_Source": "I", "Voltage_Source": "V"}
+        return prefixes.get(comp_type, "X")
+    
+    def _auto_terminals(self, comp_type: str, bbox: BoundingBox) -> List[TerminalInfo]:
+        """Auto-generate terminal positions from bbox"""
+        cx, cy = bbox.center.x, bbox.center.y
+        
+        if comp_type in ["NMOS", "PMOS", "MOSFET"]:
+            return [
+                TerminalInfo(name="drain", position=Point(x=cx, y=bbox.y_min)),
+                TerminalInfo(name="gate", position=Point(x=bbox.x_min, y=cy)),
+                TerminalInfo(name="source", position=Point(x=cx, y=bbox.y_max)),
+            ]
+        elif comp_type in ["Ground", "GND", "Current_Source", "Voltage_Source"]:
+            return [TerminalInfo(name="terminal", position=Point(x=cx, y=bbox.y_min))]
+        else:
+            # 2-terminal default
+            if bbox.height > bbox.width:
+                return [
+                    TerminalInfo(name="pin1", position=Point(x=cx, y=bbox.y_min)),
+                    TerminalInfo(name="pin2", position=Point(x=cx, y=bbox.y_max)),
+                ]
+            else:
+                return [
+                    TerminalInfo(name="pin1", position=Point(x=bbox.x_min, y=cy)),
+                    TerminalInfo(name="pin2", position=Point(x=bbox.x_max, y=cy)),
+                ]
+    
+    def evaluate_metrics(self, output: Dict[str, Any], context: AgentContext) -> Dict[str, float]:
+        yolo_detections = context.original_input.get("yolo_detections", [])
+        yolo_count = len(yolo_detections)
+        components = output.get("components", [])
+        rejected = output.get("rejected", [])
+        corrected = output.get("corrected", [])
+        
+        processed = len(components) + len(rejected)
+        
+        metrics = {}
+        
+        # 1. Coverage: Did we process all detections?
+        metrics["coverage"] = processed / max(yolo_count, 1)
+
+        # 2. Engagement: Did the agent actively validate detections?
+        # Rewards: corrections made (any confidence) + low-conf items caught
+        # Penalizes: zero engagement on a batch that had uncertain detections
+        low_conf_items = [d for d in yolo_detections if d.get('confidence', 1.0) < 0.7]
+        n_low_conf = len(low_conf_items)
+
+        if n_low_conf == 0:
+            # All detections were high-confidence — pass-through is acceptable
+            metrics["smart_corrections"] = 1.0
+        else:
+            # At least some uncertain detections exist — agent should have engaged
+            # Count how many low-conf items were corrected or rejected (i.e. acted on)
+            low_conf_ids = {i for i, d in enumerate(yolo_detections) if d.get('confidence', 1.0) < 0.7}
+            corrected_ids = {c.get('idx', -1) for c in corrected}
+            rejected_ids = {r.get('idx', -1) for r in rejected}
+            acted_on = low_conf_ids & (corrected_ids | rejected_ids)
+            # Partial credit: any corrections at all (even high-conf) show the agent looked
+            any_corrections = len(corrected) > 0 or len(rejected) > 0
+            engagement = len(acted_on) / n_low_conf
+            metrics["smart_corrections"] = engagement if engagement > 0 else (0.5 if any_corrections else 0.0)
+
+        # 3. Rejection sanity: Rejection rate should be reasonable (0-50%)
+        rejection_rate = len(rejected) / max(yolo_count, 1)
+        if rejection_rate <= 0.5:
+            metrics["rejection_sanity"] = 1.0
+        else:
+            metrics["rejection_sanity"] = max(0, 1.0 - (rejection_rate - 0.5) * 2)
+        
+        # 5. Type diversity: Circuit should have realistic component mix
+        types = set(comp.type if hasattr(comp, 'type') else comp.get('type', '') for comp in components)
+        has_active = bool(types & {'NMOS', 'PMOS', 'MOSFET', 'NPN', 'PNP', 'OpAmp'})
+        has_passive = bool(types & {'Resistor', 'Capacitor', 'Inductor'})
+        has_reference = bool(types & {'Ground', 'VDD', 'Voltage_Source', 'Current_Source'})
+        
+        # Most circuits need at least ground/power reference
+        metrics["type_completeness"] = (0.5 if has_reference else 0) + (0.25 if has_active else 0.25) + (0.25 if has_passive else 0.25)
+        
+        return metrics
+    
+    def build_error_context(self, output: Dict[str, Any], metrics: Dict[str, float], context: AgentContext) -> AgentContext:
+        new_ctx = AgentContext(original_input=context.original_input)
+        errors = []
+        
+        if metrics.get("coverage", 0) < 0.9:
+            errors.append(f"Process all {len(context.original_input.get('yolo_detections', []))} detections")
+        
+        if metrics.get("terminal_validity", 0) < 0.8:
+            errors.append("Some components have wrong terminal count - check component types")
+        
+        if metrics.get("type_completeness", 0) < 0.6:
+            errors.append("Circuit missing essential components (ground/power reference)")
+        
+        if metrics.get("rejection_sanity", 0) < 0.7:
+            errors.append("Too many rejections - verify each rejection is justified")
+        
+        new_ctx.errors = errors
+        new_ctx.previous_output = output
+        return new_ctx
+    
+    def _get_metric_weights(self) -> Dict[str, float]:
+        return {
+            "coverage": 0.50,           # Process all detections
+            "smart_corrections": 0.25,  # Agent engaged with uncertain detections
+            "rejection_sanity": 0.25    # Reasonable rejection rate
+        }
+    
+    def _get_metric_target(self, metric: str) -> float:
+        return {
+            "coverage": 0.95,
+            "terminal_validity": 0.90,
+            "smart_corrections": 0.70,
+            "rejection_sanity": 0.80,
+            "type_completeness": 0.75
+        }.get(metric, 0.7)

--- a/agents_v2/agents/connectivity_agent.py
+++ b/agents_v2/agents/connectivity_agent.py
@@ -1,0 +1,247 @@
+"""
+Connectivity Refinement Agent (Agent 2) - SIMPLIFIED
+
+LLM only validates Hough lines. No coordinate generation.
+All spatial data comes from Hough transform.
+"""
+
+import re
+import json
+from typing import Dict, Any, List
+
+from .base_agent import BaseReActAgent, AgentContext
+from ..models.components import Point
+from ..models.wires import WireInfo
+from ..models.nodes import NodeInfo
+from ..config import PipelineConfig
+
+
+class ConnectivityRefinementAgent(BaseReActAgent):
+    """
+    Agent 2: Wire Validation
+    
+    LLM ONLY outputs: which Hough lines to keep as wires
+    ALL coordinates come from Hough, never from LLM
+    """
+    
+    def __init__(self, model: str, config: PipelineConfig):
+        super().__init__(
+            agent_name="connectivity_refinement",
+            model=model,
+            config=config,
+            requires_vision=True
+        )
+    
+    def get_max_iterations(self) -> int:
+        return 2
+    
+    def get_pass_threshold(self) -> float:
+        return 0.65
+    
+    def get_min_viable_threshold(self) -> float:
+        return 0.40
+    
+    def get_system_prompt(self) -> str:
+        return """You validate Hough line detections from circuit schematics.
+
+For each line, decide if it's a wire (connecting components) or noise/edge.
+
+Output JSON with decisions and any missed wires:
+```json
+{
+  "decisions": [
+    {"idx": 0, "wire": true},
+    {"idx": 1, "wire": true},
+    {"idx": 2, "wire": false, "reason": "component edge"}
+  ],
+  "missed_connections": [
+    {"from": "R1.pin2", "to": "M1.gate", "reason": "wire visible but not detected by Hough"}
+  ]
+}
+```
+
+For missed wires: describe what components should connect. DO NOT generate coordinates."""
+    
+    def build_user_prompt(self, context: AgentContext, iteration: int) -> str:
+        hough_lines = context.original_input.get("hough_lines", [])
+        components = context.original_input.get("components", [])
+        
+        prompt = f"Validate {len(hough_lines)} Hough lines.\n\n"
+        prompt += f"Components: {len(components)}\n"
+        
+        for i, comp in enumerate(components):
+            if hasattr(comp, 'id'):
+                prompt += f"  {comp.id}: {comp.type}\n"
+            else:
+                prompt += f"  {comp.get('id', '?')}: {comp.get('type', '?')}\n"
+        
+        prompt += f"\nHough lines:\n"
+        for i, line in enumerate(hough_lines):
+            s = line.get("start", {})
+            e = line.get("end", {})
+            prompt += f"[{i}] ({s.get('x',0)},{s.get('y',0)}) → ({e.get('x',0)},{e.get('y',0)})\n"
+        
+        return prompt
+    
+    def parse_response(self, response: str, context: AgentContext) -> Dict[str, Any]:
+        """Parse wire decisions and build from Hough data"""
+        
+        hough_lines = context.original_input.get("hough_lines", [])
+        
+        # Try JSON object first (new format), then array
+        decisions = []
+        missed_connections = []
+        
+        json_obj_match = re.search(r'\{[\s\S]*\}', response)
+        if json_obj_match:
+            try:
+                data = json.loads(json_obj_match.group(0))
+                decisions = data.get("decisions", [])
+                missed_connections = data.get("missed_connections", [])
+            except:
+                pass
+        
+        # Fallback to array format
+        if not decisions:
+            json_arr_match = re.search(r'\[[\s\S]*\]', response)
+            if json_arr_match:
+                try:
+                    decisions = json.loads(json_arr_match.group(0))
+                except:
+                    decisions = []
+        
+        # If no valid decisions, keep all lines as wires
+        if not decisions:
+            print(f"    No valid decisions, keeping all {len(hough_lines)} Hough lines as wires")
+            decisions = [{"idx": i, "wire": True} for i in range(len(hough_lines))]
+        
+        # Build wires from Hough data
+        wires = []
+        rejected_count = 0
+        
+        for dec in decisions:
+            idx = dec.get("idx", dec.get("index", -1))
+            is_wire = dec.get("wire", True)
+            
+            if idx < 0 or idx >= len(hough_lines):
+                continue
+            
+            if not is_wire:
+                rejected_count += 1
+                continue
+            
+            hough = hough_lines[idx]
+            start = hough.get("start", {})
+            end = hough.get("end", {})
+            
+            wire = WireInfo(
+                id=f"W{len(wires)+1}",
+                path=[
+                    Point(x=int(start.get("x", 0)), y=int(start.get("y", 0))),
+                    Point(x=int(end.get("x", 0)), y=int(end.get("y", 0)))
+                ],
+                source_hough_ids=[idx],
+                source="hough",
+                confidence=0.7
+            )
+            wire.compute_properties()
+            wires.append(wire)
+        
+        # Create basic nodes
+        nodes = [
+            NodeInfo(id="0", type="ground", is_ground=True),
+            NodeInfo(id="VDD", type="power", is_power=True),
+        ]
+        
+        return {
+            "wires": wires,
+            "nodes": nodes,
+            "rejected_count": rejected_count,
+            "actions": [f"Created {len(wires)} wires, rejected {rejected_count} lines"]
+        }
+    
+    def evaluate_metrics(self, output: Dict[str, Any], context: AgentContext) -> Dict[str, float]:
+        hough_lines = context.original_input.get("hough_lines", [])
+        hough_count = len(hough_lines)
+        components = context.original_input.get("components", [])
+        wires = output.get("wires", [])
+        nodes = output.get("nodes", [])
+        rejected_count = output.get("rejected_count", 0)
+        
+        processed = len(wires) + rejected_count
+        
+        metrics = {}
+        
+        # 1. Coverage: Did we process all Hough lines?
+        metrics["coverage"] = processed / max(hough_count, 1)
+        
+        # 2. Wire-to-component ratio: Should have ~1-3 wires per component
+        comp_count = len(components)
+        if comp_count > 0:
+            ratio = len(wires) / comp_count
+            if 0.5 <= ratio <= 5.0:
+                metrics["wire_ratio"] = 1.0
+            elif ratio < 0.5:
+                metrics["wire_ratio"] = ratio * 2  # Too few wires
+            else:
+                metrics["wire_ratio"] = max(0.5, 1.0 - (ratio - 5.0) / 10.0)
+        else:
+            metrics["wire_ratio"] = 0.5
+        
+        # 3. Node essentials: Must have ground, should have power
+        has_ground = any(
+            (n.is_ground if hasattr(n, 'is_ground') else n.get('is_ground', False)) or
+            (n.id if hasattr(n, 'id') else n.get('id', '')) == '0'
+            for n in nodes
+        )
+        has_power = any(
+            (n.is_power if hasattr(n, 'is_power') else n.get('is_power', False)) or
+            (n.id if hasattr(n, 'id') else n.get('id', '')) in ['VDD', 'VCC', 'vdd', 'vcc']
+            for n in nodes
+        )
+        metrics["essential_nodes"] = (0.6 if has_ground else 0) + (0.4 if has_power else 0)
+        
+        # 4. Filtering sanity: Should filter some lines (not all, not none)
+        if hough_count > 0:
+            filter_rate = rejected_count / hough_count
+            if 0.05 <= filter_rate <= 0.8:
+                metrics["filter_sanity"] = 1.0
+            elif filter_rate < 0.05:
+                metrics["filter_sanity"] = 0.8  # Keeping almost all
+            else:
+                metrics["filter_sanity"] = max(0.3, 1.0 - filter_rate)
+        else:
+            metrics["filter_sanity"] = 0.5
+        
+        return metrics
+    
+    def build_error_context(self, output: Dict[str, Any], metrics: Dict[str, float], context: AgentContext) -> AgentContext:
+        new_ctx = AgentContext(original_input=context.original_input)
+        errors = []
+        
+        if metrics.get("essential_nodes", 0) < 0.6:
+            errors.append("Missing ground node (id='0')")
+        if metrics.get("wire_ratio", 0) < 0.5:
+            errors.append("Too few wires for component count")
+        if metrics.get("filter_sanity", 0) < 0.5:
+            errors.append("Wire filtering seems off - check decisions")
+        
+        new_ctx.errors = errors
+        new_ctx.previous_output = output
+        return new_ctx
+    
+    def _get_metric_weights(self) -> Dict[str, float]:
+        return {
+            "coverage": 0.25,
+            "wire_ratio": 0.25,
+            "essential_nodes": 0.30,
+            "filter_sanity": 0.20
+        }
+    
+    def _get_metric_target(self, metric: str) -> float:
+        return {
+            "coverage": 0.90,
+            "wire_ratio": 0.80,
+            "essential_nodes": 0.80,
+            "filter_sanity": 0.70
+        }.get(metric, 0.7)

--- a/agents_v2/agents/judge_agent.py
+++ b/agents_v2/agents/judge_agent.py
@@ -1,0 +1,548 @@
+"""
+LLM-as-Judge: Cross-Validation Agent (MANDATORY)
+
+Performs semantic validation between:
+- Original topology from Agent 2
+- Generated SPICE netlist from Agent 3
+
+Uses GPT-5.2-pro for highest reasoning capability.
+"""
+
+import json
+import re
+import os
+import time
+import base64
+from io import BytesIO
+from typing import Dict, List, Any, Optional, Tuple
+
+from openai import OpenAI
+from PIL import Image as PILImage
+
+from ..config import PipelineConfig
+from ..models.components import ComponentInfo
+from ..models.nodes import NodeInfo
+
+
+_SCAFFOLDING_PREFIXES = (
+    "VSUP_", "VB_", "VTEST_", "ISUP_", "IBIAS_", "ITEST_",
+    "RSHUNT_", "RPROBE_",
+)
+_SCAFFOLDING_EXACT = {"VDD", "VSS", "VCC", "VEE", "AVDD", "DVDD"}
+_SCAFFOLDING_SINGLE_LETTER = set("BGEFDH")  # behavioral / controlled sources
+
+
+def is_scaffolding_component(token: str) -> bool:
+    """Return True if this netlist component ID is a known scaffolding element."""
+    upper = token.upper()
+    if upper in _SCAFFOLDING_EXACT:
+        return True
+    if any(upper.startswith(p) for p in _SCAFFOLDING_PREFIXES):
+        return True
+    if len(token) >= 1 and token[0].upper() in _SCAFFOLDING_SINGLE_LETTER:
+        return True
+    return False
+
+
+def translate_spice_errors(logs: str) -> List[str]:
+    """Convert common ngspice error strings into human-readable fix suggestions."""
+    fixes = []
+    log_lower = logs.lower()
+    if "unknown parameter" in log_lower or "unknown device" in log_lower:
+        fixes.append("Unknown component type — check model cards and component prefixes.")
+    if "node is floating" in log_lower or "floating node" in log_lower:
+        fixes.append("Floating node detected — every node must connect to at least two components.")
+    if "singular matrix" in log_lower:
+        fixes.append("Singular matrix — likely a floating node or disconnected subcircuit.")
+    if "undefined node" in log_lower:
+        fixes.append("Undefined node name — check for typos in node labels.")
+    if "no dc path" in log_lower:
+        fixes.append("No DC path to ground — ensure all nodes have a path to node 0.")
+    return fixes
+
+
+class LLMJudge:
+    """
+    LLM-as-Judge for mandatory cross-validation.
+    
+    This is NOT a ReAct agent - it's a single-pass evaluator
+    that produces a judgment with issues.
+    """
+    
+    def __init__(self, model: str = "gpt-5.2", config: Optional[PipelineConfig] = None):
+        self.model = model
+        self.config = config or PipelineConfig()
+        
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OpenAI API key not found. Set OPENAI_API_KEY environment variable."
+            )
+        self.client = OpenAI(api_key=api_key)
+        self.total_tokens = 0
+        self.llm_call_history: List[Dict] = []
+    
+    def judge(
+        self,
+        topology_components: List[Any],
+        topology_nodes: List[Any],
+        spice_code: str,
+        retry_on_fail: bool = True,
+        simulation_logs: str = "",
+        simulation_success: bool = False,
+        image: Optional[PILImage.Image] = None,
+        corrected: Optional[List[Dict]] = None,
+        agent_added: Optional[List[Dict]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Judge whether the SPICE netlist correctly represents the topology.
+
+        Args:
+            topology_components: Validated components from Agent 1
+            topology_nodes: (unused, kept for API compat)
+            spice_code: SPICE netlist from Agent 2
+            simulation_logs: ngspice stdout/stderr
+            simulation_success: ngspice pass/fail (objective)
+            image: Original circuit image for visual topology verification
+            corrected: List of type corrections Agent 1 made
+            agent_added: List of components Agent 1 added (missed by YOLO)
+
+        Returns:
+            {
+                "verdict": "PASS" | "FAIL",
+                "confidence": 0.0-1.0,  # criteria-based, not LLM vibe
+                "criteria": {...},       # C1-C5 individual results
+                "component_mapping": {...},
+                "node_mapping": {...},
+                "issues": [...],
+                "explanation": "..."
+            }
+        """
+        
+        system_prompt = self._get_system_prompt()
+        user_prompt = self._build_user_prompt(
+            topology_components, topology_nodes, spice_code,
+            simulation_logs=simulation_logs,
+            simulation_success=simulation_success,
+            corrected=corrected or [],
+            agent_added=agent_added or [],
+        )
+        
+        # Build user message content — text + optional image
+        user_content: List[Any] = []
+        if image is not None:
+            # Cap at 1024px longest side — sufficient for vision, avoids token explosion
+            _img = image.copy()
+            if max(_img.size) > 1024:
+                _img.thumbnail((1024, 1024))
+            if _img.mode in ("RGBA", "P"):
+                _img = _img.convert("RGB")
+            buffered = BytesIO()
+            _img.save(buffered, format="JPEG", quality=85)
+            img_b64 = base64.b64encode(buffered.getvalue()).decode()
+            user_content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}
+            })
+        user_content.append({"type": "text", "text": user_prompt})
+
+        max_attempts = self.config.iterations.judge_max_retries + 1 if retry_on_fail else 1
+
+        for attempt in range(max_attempts):
+            try:
+                # Build API params - handle different parameter names
+                api_params = {
+                    "model": self.model,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_content}
+                    ],
+                    "temperature": 0.1  # Low temperature for consistent judgment
+                }
+                
+                # Newer models use max_completion_tokens
+                if any(x in self.model.lower() for x in ["o1", "o3", "o4", "gpt-5", "5.2"]):
+                    api_params["max_completion_tokens"] = 2048
+                else:
+                    api_params["max_tokens"] = 2048
+                
+                response = self.client.chat.completions.create(**api_params)
+                
+                self.total_tokens += response.usage.total_tokens if response.usage else 0
+                content = response.choices[0].message.content or ""
+
+                # Log this LLM call for debugging/analysis
+                cache_stats = {}
+                if response.usage and hasattr(response.usage, 'prompt_tokens_details'):
+                    details = response.usage.prompt_tokens_details
+                    cache_stats = {
+                        'total_tokens': response.usage.total_tokens,
+                        'cached_tokens': getattr(details, 'cached_tokens', 0),
+                        'prompt_tokens': response.usage.prompt_tokens,
+                        'completion_tokens': response.usage.completion_tokens
+                    }
+
+                self.llm_call_history.append({
+                    "iteration": attempt + 1,
+                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    "model": self.model,
+                    "prompt": {
+                        "system": system_prompt,
+                        "user": user_prompt
+                    },
+                    "response": content,
+                    "tokens": cache_stats if cache_stats else {"total_tokens": response.usage.total_tokens if response.usage else 0},
+                    "retry_attempt": attempt
+                })
+
+                result = self._parse_judgment(content, simulation_success)
+
+                # Validate result
+                if "verdict" in result and "confidence" in result:
+                    return result
+
+            except Exception as e:
+                if attempt == max_attempts - 1:
+                    return {
+                        "verdict": "FAIL",
+                        "confidence": 0.0,
+                        "criteria": {},
+                        "issues": [f"Judge error: {str(e)}"],
+                        "explanation": "Failed to evaluate due to error"
+                    }
+
+        return {
+            "verdict": "FAIL",
+            "confidence": 0.0,
+            "criteria": {},
+            "issues": ["Failed to produce valid judgment"],
+            "explanation": "Judge could not evaluate the netlist"
+        }
+    
+    def _get_system_prompt(self) -> str:
+        return """You are an expert circuit verification engineer evaluating an auto-generated SPICE netlist.
+
+**PIPELINE CONTEXT**:
+1. Agent 1 (vision) validated YOLO detections → produced component list with IDs (M1, R1, etc.), corrected types, and flagged missed components
+2. Agent 2 (vision) looked at the circuit image → generated SPICE netlist inferring connectivity
+3. You verify both using 5 explicit criteria (C1–C5) and provide targeted feedback
+
+**SPICE LINE STRUCTURE**:
+- First token on each line = component ID (e.g. M1, R1, V1)
+- Remaining tokens = node names (vdd, gnd, 0, in, out...) — NEVER treat these as components
+- Example: `V1 vdd 0 DC 1.8` → ID=V1, nodes=vdd,0. Do NOT flag vdd as a hallucination.
+
+**SCAFFOLDING (DO NOT FLAG)**:
+- Supply names: VDD, VSS, VCC, VEE, AVDD, DVDD
+- Prefixes: VSUP_*, VB_*, VTEST_*, ISUP_*, IBIAS_*, ITEST_*, RSHUNT_*, RPROBE_*, B*, G*, E*, F*, H*
+
+**GROUND HANDLING**:
+- Ground components are implicit in SPICE as node "0" — mark them as IMPLICIT, never expect a component line for them
+
+═══════════════════════════════════════════════
+EVALUATION CRITERIA (score each independently)
+═══════════════════════════════════════════════
+
+**C1 — Simulation validity** (HARD RULE — objective)
+- PASS: ngspice simulation succeeded
+- FAIL: ngspice simulation failed for any reason
+- If C1=FAIL → overall verdict MUST be FAIL regardless of other criteria
+
+**C2 — Component completeness** (HARD RULE — checkable)
+- PASS: every validated component ID (except Ground) appears in the netlist exactly once, no duplicates
+- FAIL: any validated component missing OR any ID duplicated
+- If C2=FAIL → overall verdict MUST be FAIL regardless of other criteria
+
+**C3 — Component type match** (visual check using the circuit image)
+- Look at the circuit image. Do the component symbols you see match the types in the validated list?
+- PASS: types are consistent with what you see in the image
+- FAIL: clear mismatch (e.g. validated list says NMOS but image shows a resistor symbol in that bbox)
+- Note any corrections Agent 1 already made — these are shown explicitly
+
+**C4 — Topological plausibility** (visual check using the circuit image)
+- Look at the circuit image. Do the netlist connections make sense given the visual layout?
+- Check: power rail at top connects to correct terminals, ground at bottom, signal flow is coherent
+- PASS: connections are plausible given the image
+- FAIL: clear topological error visible (e.g. drain connected to ground when it clearly goes to VDD)
+- Be lenient — you cannot verify every wire, only obvious errors
+
+**C5 — No hallucinations** (checkable)
+- PASS: no non-scaffolding component IDs in the netlist that are not in the validated list
+- FAIL: extra non-scaffolding components invented by Agent 2
+
+═══════════════════════════════════════════════
+CONFIDENCE SCORING
+═══════════════════════════════════════════════
+Confidence is computed from C3+C4+C5 (the LLM-evaluated criteria):
+- All 3 pass → confidence = 1.0
+- 2 pass → confidence = 0.8
+- 1 passes → confidence = 0.5
+- 0 pass → confidence = 0.2
+Do NOT invent your own confidence number — use the formula above.
+
+Overall PASS requires: C1=PASS AND C2=PASS AND confidence ≥ 0.80
+
+═══════════════════════════════════════════════
+OUTPUT FORMAT
+═══════════════════════════════════════════════
+```json
+{
+  "thinking": "Step by step: check C1, C2, then look at image for C3/C4, then C5...",
+
+  "criteria": {
+    "C1_simulation": {"pass": true, "notes": "ngspice passed"},
+    "C2_completeness": {"pass": true, "notes": "all IDs present exactly once"},
+    "C3_type_match": {"pass": true, "notes": "visual symbols match validated types"},
+    "C4_topology": {"pass": true, "notes": "connections consistent with image layout"},
+    "C5_no_hallucinations": {"pass": true, "notes": "no extra non-scaffolding components"}
+  },
+
+  "verdict": "PASS",
+  "confidence": 1.0,
+
+  "component_mapping": {
+    "M1": {"netlist": "M1", "status": "MATCH", "notes": ""},
+    "GND1": {"netlist": null, "status": "IMPLICIT", "notes": "ground = node 0"}
+  },
+
+  "issues": [],
+
+  "explanation": "Brief summary of what passed and what failed.",
+
+  "feedback_for_agent1": "Specific feedback about component detection. Mention: wrong types, missed components, low-confidence items that look suspicious in the image. If all good, say so.",
+
+  "feedback_for_agent2": "Specific feedback about netlist generation. Mention: wrong connections visible in image, missing/duplicate components, simulation errors to fix. If all good, say so."
+}
+```
+
+**CRITICAL**: C1=FAIL or C2=FAIL → verdict=FAIL, no exceptions. Always fill both feedback fields."""
+    
+    def _build_user_prompt(
+        self,
+        components: List[Any],
+        nodes: List[Any],
+        spice_code: str,
+        simulation_logs: str = "",
+        simulation_success: bool = False,
+        corrected: Optional[List[Dict]] = None,
+        agent_added: Optional[List[Dict]] = None,
+    ) -> str:
+        """Build the verification prompt with component details, correction history, and sim results."""
+
+        sim_status = "PASSED" if simulation_success else "FAILED"
+        prompt = f"""Evaluate this circuit netlist using criteria C1–C5. Simulation result (C1) is already known: {sim_status}.
+
+═══════════════════════════════════════════════════════════
+ORIGINAL TOPOLOGY
+═══════════════════════════════════════════════════════════
+
+COMPONENTS:
+"""
+        for i, comp in enumerate(components, 1):
+            if isinstance(comp, ComponentInfo):
+                connections = ", ".join(
+                    f"{t.name}→{t.connected_to_node}" 
+                    for t in comp.terminals
+                )
+                prompt += f"  {comp.id} ({comp.type}): {connections}\n"
+            elif isinstance(comp, dict):
+                prompt += f"{i}. ID: {comp.get('id','?')}, Type: {comp.get('type','?')}"
+                if comp.get('source'):
+                    prompt += f", Source: {comp['source']}"
+                if comp.get('confidence') is not None:
+                    prompt += f", Confidence: {comp['confidence']:.2f}"
+                if comp.get('refinement_notes'):
+                    prompt += f", Notes: {comp['refinement_notes']}"
+                prompt += "\n"
+
+        # Agent 1 correction history — useful for C3 visual verification
+        if corrected:
+            prompt += f"\nAGENT 1 TYPE CORRECTIONS ({len(corrected)}):\n"
+            for c in corrected:
+                prompt += (f"  - [{c.get('idx','?')}] {c.get('yolo_type','?')} → "
+                           f"{c.get('corrected_type','?')} "
+                           f"(YOLO conf: {c.get('yolo_conf', 0):.2f}): {c.get('reason','')}\n")
+
+        if agent_added:
+            prompt += f"\nCOMPONENTS ADDED BY AGENT 1 (missed by YOLO, {len(agent_added)}):\n"
+            for a in agent_added:
+                prompt += f"  - {a.get('type','?')} at {a.get('location','?')}: {a.get('reason','')}\n"
+
+        # Parse netlist component IDs
+        core_parsed = []
+        scaffolding_parsed = []
+        for line in spice_code.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith(("*", ".", ";", "#", "//")):
+                continue
+            first_token = stripped.split()[0]
+            if is_scaffolding_component(first_token):
+                scaffolding_parsed.append(first_token)
+            else:
+                core_parsed.append(first_token)
+
+        prompt += f"""
+═══════════════════════════════════════════════════════════
+GENERATED SPICE NETLIST:
+═══════════════════════════════════════════════════════════
+
+{spice_code}
+
+CORE COMPONENT IDs IN NETLIST (must match validated list):
+{', '.join(core_parsed) if core_parsed else 'None'}
+
+SCAFFOLDING ELEMENTS (allowed — do NOT flag):
+{', '.join(scaffolding_parsed) if scaffolding_parsed else 'None'}
+"""
+
+        # Simulation results
+        prompt += f"""
+═══════════════════════════════════════════════════════════
+C1 — SIMULATION: {sim_status}
+═══════════════════════════════════════════════════════════
+"""
+        if simulation_logs:
+            prompt += f"{simulation_logs[:2000]}\n"
+            if not simulation_success:
+                translations = translate_spice_errors(simulation_logs)
+                if translations:
+                    prompt += "\nACTIONABLE FIXES:\n"
+                    for t in translations:
+                        prompt += f"  - {t}\n"
+
+        prompt += """
+═══════════════════════════════════════════════════════════
+
+Evaluate C1–C5 as defined in the system prompt.
+If an image was provided, use it for C3 (type match) and C4 (topology plausibility).
+Compute confidence from C3+C4+C5 using the formula in the system prompt.
+Output your judgment as JSON."""
+
+        return prompt
+    
+    def _parse_judgment(self, response: str, simulation_success: bool = False) -> Dict[str, Any]:
+        """Parse judge response, enforce hard C1/C2 rules, compute criteria-based confidence."""
+
+        # Extract JSON
+        json_match = re.search(r'```json\s*(.*?)\s*```', response, re.DOTALL)
+        if json_match:
+            json_str = json_match.group(1)
+        else:
+            json_match = re.search(r'\{[\s\S]*\}', response)
+            if json_match:
+                json_str = json_match.group(0)
+            else:
+                return {
+                    "verdict": "FAIL",
+                    "confidence": 0.0,
+                    "criteria": {},
+                    "component_mapping": {},
+                    "issues": ["Could not parse structured response"],
+                    "explanation": response[:500]
+                }
+
+        try:
+            data = json.loads(json_str)
+        except json.JSONDecodeError:
+            return {
+                "verdict": "FAIL",
+                "confidence": 0.0,
+                "criteria": {},
+                "issues": ["Failed to parse judgment JSON"],
+                "explanation": response[:500]
+            }
+
+        # Extract criteria block
+        criteria = data.get("criteria", {})
+
+        # C1: hard rule — use actual ngspice result, not LLM opinion
+        c1_pass = simulation_success
+        if "C1_simulation" in criteria:
+            criteria["C1_simulation"]["pass"] = c1_pass
+        else:
+            criteria["C1_simulation"] = {"pass": c1_pass, "notes": "ngspice result (objective)"}
+
+        # C2: use LLM judgment on completeness
+        c2 = criteria.get("C2_completeness", {})
+        c2_pass = bool(c2.get("pass", True))
+
+        # C3, C4, C5: LLM-evaluated criteria
+        c3_pass = bool(criteria.get("C3_type_match", {}).get("pass", True))
+        c4_pass = bool(criteria.get("C4_topology", {}).get("pass", True))
+        c5_pass = bool(criteria.get("C5_no_hallucinations", {}).get("pass", True))
+
+        # Criteria-based confidence from C3+C4+C5 only
+        llm_criteria_passed = sum([c3_pass, c4_pass, c5_pass])
+        confidence_map = {3: 1.0, 2: 0.8, 1: 0.5, 0: 0.2}
+        confidence = confidence_map[llm_criteria_passed]
+
+        # Hard verdict rules: C1 or C2 fail → FAIL regardless
+        issues = self._normalize_issue_list(data.get("issues", []))
+        if not c1_pass:
+            verdict = "FAIL"
+            issues.insert(0, "C1 FAIL: ngspice simulation failed (hard rule)")
+        elif not c2_pass:
+            verdict = "FAIL"
+            issues.insert(0, "C2 FAIL: component completeness check failed (hard rule)")
+        else:
+            verdict = "PASS" if confidence >= 0.80 else "FAIL"
+
+        return {
+            "verdict": verdict,
+            "confidence": confidence,
+            "criteria": criteria,
+            "simulation_passed": c1_pass,
+            "component_accounting_passed": c2_pass,
+            "component_mapping": data.get("component_mapping", {}),
+            "issues": issues,
+            "explanation": str(data.get("explanation", "")),
+            "thinking": data.get("thinking", ""),
+            "feedback_for_agent1": str(data.get("feedback_for_agent1", "")),
+            "feedback_for_agent2": str(data.get("feedback_for_agent2", "")),
+        }
+
+    def _normalize_issue_list(self, issues: Any) -> List[str]:
+        """Ensure issues is a flat list of strings."""
+        if isinstance(issues, list):
+            return [str(i) for i in issues if i]
+        if isinstance(issues, str):
+            return [issues] if issues else []
+        return []
+    
+    def get_pass_threshold(self) -> float:
+        return self.config.thresholds.judge_pass_threshold
+    
+    def is_pass(self, result: Dict[str, Any]) -> bool:
+        """Check if judgment is a pass"""
+        return (
+            result.get("verdict") == "PASS" and
+            result.get("confidence", 0) >= self.get_pass_threshold()
+        )
+    
+    def get_feedback_for_retry(self, result: Dict[str, Any]) -> Dict[str, Any]:
+        """Get structured feedback to send back to Agent 3 for retry"""
+        
+        issues = result.get("issues", [])
+        component_mapping = result.get("component_mapping", {})
+        node_mapping = result.get("node_mapping", {})
+        
+        # Find specific problems
+        component_issues = []
+        for comp_id, mapping in component_mapping.items():
+            if isinstance(mapping, dict) and mapping.get("status") not in ["MATCH", "IMPLICIT", "OK"]:
+                component_issues.append(
+                    f"{comp_id}: {mapping.get('notes', 'Issue found')}"
+                )
+        
+        node_issues = []
+        for node_id, mapping in node_mapping.items():
+            if isinstance(mapping, dict) and mapping.get("status") not in ["MATCH", "OK"]:
+                node_issues.append(f"{node_id}: mismatch in netlist")
+        
+        return {
+            "verdict": result.get("verdict"),
+            "confidence": result.get("confidence"),
+            "errors": issues + component_issues + node_issues,
+            "feedback": result.get("explanation", ""),
+            "needs_retry": not self.is_pass(result)
+        }

--- a/agents_v2/agents/netlist_agent.py
+++ b/agents_v2/agents/netlist_agent.py
@@ -1,0 +1,672 @@
+"""
+Agent 3: Netlist Generation Agent
+
+Generates SPICE netlist from topology:
+- Converts components and nodes to SPICE format
+- Adds simulation directives
+- Validates syntax and runs simulation
+"""
+
+import json
+import re
+import subprocess
+import tempfile
+import os
+from typing import Dict, List, Any, Optional
+from pathlib import Path
+
+from .base_agent import BaseReActAgent, AgentContext
+from ..config import PipelineConfig
+from ..models.components import ComponentInfo
+from ..models.nodes import NodeInfo
+from ..models.output import NetlistOutput
+
+
+class NetlistGenerationAgent(BaseReActAgent):
+    """
+    Agent 3: Netlist Generation
+    
+    Converts topology to valid SPICE netlist.
+    Does NOT require vision - works from structured topology only.
+    """
+    
+    def __init__(self, model: str = "gpt-5.2", config: Optional[PipelineConfig] = None):
+        super().__init__(
+            agent_name="Agent 3: Netlist Generation",
+            model=model,
+            config=config or PipelineConfig(),
+            requires_vision=False  # No vision needed - structured input only
+        )
+        self.netlist_output = NetlistOutput()
+        self.output_dir = Path(config.output_dir if config else "agents_v2_output")
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+    
+    def get_max_iterations(self) -> int:
+        return self.config.iterations.agent3_max_iterations
+    
+    def get_pass_threshold(self) -> float:
+        return self.config.thresholds.agent3_pass_threshold
+    
+    def get_min_viable_threshold(self) -> float:
+        return self.config.thresholds.agent3_min_viable_threshold
+    
+    def get_system_prompt(self) -> str:
+        return """You are an expert SPICE netlist generator. Your task is to convert circuit topology to valid SPICE netlist.
+
+You will receive:
+1. List of components with their terminal-to-node connections
+2. List of electrical nodes
+3. (On iterations 2+) Simulation errors to fix
+
+SPICE Netlist Format Rules:
+- First line is the circuit title
+- Comments start with *
+- Component format: NAME NODE1 NODE2 [NODE3...] VALUE
+- Ground must be node 0
+- End with .END
+
+Component Syntax:
+- Resistor: R<name> <node1> <node2> <value>  (e.g., R1 n1 n2 10k)
+- Capacitor: C<name> <node1> <node2> <value> (e.g., C1 n1 0 1u)
+- Inductor: L<name> <node1> <node2> <value>  (e.g., L1 n1 n2 100u)
+- MOSFET: M<name> <drain> <gate> <source> <bulk> <model> W=<w> L=<l>
+  (e.g., M1 out in 0 0 NMOS W=1u L=180n)
+- Voltage: V<name> <+node> <-node> <value> (e.g., VDD vdd 0 1.8)
+- Current: I<name> <+node> <-node> <value> (e.g., I1 vdd out 10u)
+- BJT: Q<name> <collector> <base> <emitter> <model>
+- Diode: D<name> <anode> <cathode> <model>
+
+Required Additions:
+- Add VDD voltage source if not present (e.g., VDD vdd 0 1.8)
+- Add MOSFET models if MOSFETs used
+- Add basic simulation commands (.OP for DC operating point)
+
+Output as JSON:
+```json
+{
+  "thinking": "Your netlist generation reasoning...",
+  
+  "netlist": {
+    "title": "Circuit Netlist",
+    "components": [
+      {"line": "R1 n1 n2 10k", "comment": "Resistor R1 between n1 and n2"},
+      {"line": "M1 n1 gate 0 0 NMOS W=1u L=180n", "comment": "NMOS transistor"}
+    ],
+    "sources": [
+      {"line": "VDD vdd 0 1.8", "comment": "Power supply"}
+    ],
+    "models": [
+      {"line": ".model NMOS NMOS (VTH0=0.4 KP=200u)", "comment": "NMOS model"}
+    ],
+    "simulation": [
+      {"line": ".OP", "comment": "DC operating point"},
+      {"line": ".END", "comment": "End of netlist"}
+    ]
+  },
+  
+  "spice_code": "* Circuit Netlist\\n* Components\\nR1 n1 n2 10k\\n...",
+  
+  "node_mapping": {
+    "VDD": "vdd",
+    "0": "0", 
+    "node_1": "n1",
+    "node_2": "n2"
+  },
+  
+  "summary": {
+    "total_components": 5,
+    "total_nodes": 4,
+    "has_ground": true,
+    "has_power_source": true
+  }
+}
+```
+
+Ensure all node names are SPICE-compatible (alphanumeric, no spaces)."""
+    
+    def build_user_prompt(self, context: AgentContext, iteration: int) -> str:
+        """Build prompt with topology data"""
+        
+        components = context.original_input.get("components", [])
+        nodes = context.original_input.get("nodes", [])
+        
+        prompt = """Generate a SPICE netlist from this circuit topology.
+
+COMPONENTS:
+"""
+        for comp in components:
+            if isinstance(comp, ComponentInfo):
+                connections = ", ".join(
+                    f"{t.name}→{t.connected_to_node}" 
+                    for t in comp.terminals
+                )
+                prompt += f"  {comp.id} ({comp.type}): {connections}"
+                if comp.value:
+                    prompt += f", value={comp.value}"
+                prompt += "\n"
+            else:
+                terminals = comp.get("terminals", [])
+                connections = ", ".join(
+                    f"{t.get('name')}→{t.get('connected_to_node', 'unknown')}"
+                    for t in terminals
+                )
+                prompt += f"  {comp.get('id')} ({comp.get('type')}): {connections}"
+                if comp.get("value"):
+                    prompt += f", value={comp.get('value')}"
+                prompt += "\n"
+        
+        prompt += """
+ELECTRICAL NODES:
+"""
+        for node in nodes:
+            if isinstance(node, NodeInfo):
+                node_type = "POWER" if node.is_power else "GROUND" if node.is_ground else "internal"
+                prompt += f"  {node.id} ({node_type}): {node.connected_terminals}\n"
+            else:
+                node_type = "POWER" if node.get("is_power") else "GROUND" if node.get("is_ground") else "internal"
+                prompt += f"  {node.get('id')} ({node_type}): {node.get('connected_terminals', [])}\n"
+        
+        # Add judge feedback if provided (from judge retry)
+        judge_feedback = context.original_input.get("judge_feedback")
+        if judge_feedback:
+            prompt += f"""
+
+═══════════════════════════════════════════════════════════
+JUDGE VALIDATION FEEDBACK (CRITICAL - MUST FIX):
+═══════════════════════════════════════════════════════════
+
+The previous netlist FAILED cross-validation by the LLM Judge.
+Judge Confidence: {judge_feedback.get('judge_confidence', 0.0):.2f}
+
+ERRORS FOUND:
+"""
+            for error in judge_feedback.get('errors', []):
+                prompt += f"  • {error}\n"
+
+            if judge_feedback.get('component_issues'):
+                prompt += f"""
+COMPONENT ISSUES:
+"""
+                for issue in judge_feedback.get('component_issues', []):
+                    if issue.strip():
+                        prompt += f"  • {issue}\n"
+
+            if judge_feedback.get('node_issues'):
+                prompt += f"""
+NODE MAPPING ISSUES:
+"""
+                for issue in judge_feedback.get('node_issues', []):
+                    if issue.strip():
+                        prompt += f"  • {issue}\n"
+
+            prompt += f"""
+JUDGE FEEDBACK:
+{judge_feedback.get('feedback', '')}
+
+PREVIOUS NETLIST (FAILED):
+{judge_feedback.get('previous_netlist', '')[:1000]}
+
+You MUST fix all the issues above. Pay special attention to:
+1. Component-to-netlist mapping (ensure all topology components appear)
+2. Node connections (verify each component's terminals connect correctly)
+3. SPICE syntax (ground = 0, proper component format)
+═══════════════════════════════════════════════════════════
+"""
+        # Add error context for iteration 2+ (internal agent iterations)
+        elif iteration > 1 and context.previous_output:
+            prompt += f"""
+
+═══════════════════════════════════════════════════════════
+PREVIOUS ITERATION FEEDBACK (MUST FIX THESE ERRORS):
+═══════════════════════════════════════════════════════════
+
+PREVIOUS METRICS:
+"""
+            for metric, value in context.previous_metrics.items():
+                status = "✓ PASSED" if metric in context.passed_metrics else "✗ FAILED"
+                prompt += f"  {metric}: {value:.3f} {status}\n"
+
+            prompt += f"""
+SIMULATION ERRORS:
+"""
+            for error in context.errors:
+                prompt += f"  • {error}\n"
+
+            prompt += f"""
+FEEDBACK:
+{context.feedback}
+
+Fix the errors above. The previous netlist was:
+{context.previous_output.get('spice_code', 'N/A')[:1000]}
+═══════════════════════════════════════════════════════════
+"""
+
+        prompt += """
+Generate a complete, valid SPICE netlist that will simulate successfully."""
+        
+        return prompt
+    
+    def parse_response(self, response: str, context: AgentContext) -> Dict[str, Any]:
+        """Parse LLM response into structured output - with robust fallback"""
+        
+        # Extract JSON
+        json_match = re.search(r'```json\s*(.*?)\s*```', response, re.DOTALL)
+        if json_match:
+            json_str = json_match.group(1)
+        else:
+            json_match = re.search(r'\{[\s\S]*\}', response)
+            if json_match:
+                json_str = json_match.group(0)
+            else:
+                # FALLBACK: Try to extract SPICE code directly from response
+                print(f"    ⚠ No JSON in response, trying to extract SPICE directly")
+                return self._extract_spice_fallback(response, context)
+        
+        try:
+            data = json.loads(json_str)
+        except json.JSONDecodeError as e:
+            print(f"    ⚠ JSON parse error: {e}, trying SPICE extraction fallback")
+            return self._extract_spice_fallback(response, context)
+        
+        # Get or build SPICE code
+        spice_code = data.get("spice_code", "")
+        if not spice_code:
+            # Build from structured netlist
+            netlist = data.get("netlist", {})
+            lines = [f"* {netlist.get('title', 'Circuit Netlist')}"]
+            lines.append("*")
+            
+            lines.append("* Components")
+            for comp in netlist.get("components", []):
+                lines.append(comp.get("line", ""))
+            
+            lines.append("*")
+            lines.append("* Sources")
+            for src in netlist.get("sources", []):
+                lines.append(src.get("line", ""))
+            
+            lines.append("*")
+            lines.append("* Models")
+            for model in netlist.get("models", []):
+                lines.append(model.get("line", ""))
+            
+            lines.append("*")
+            lines.append("* Simulation")
+            for sim in netlist.get("simulation", []):
+                lines.append(sim.get("line", ""))
+            
+            spice_code = "\n".join(lines)
+        
+        # Store netlist output
+        self.netlist_output.spice_code = spice_code
+        
+        actions = [
+            f"Generated netlist with {data.get('summary', {}).get('total_components', 0)} components",
+            f"Nodes: {data.get('summary', {}).get('total_nodes', 0)}"
+        ]
+        
+        return {
+            "spice_code": spice_code,
+            "netlist": data.get("netlist", {}),
+            "node_mapping": data.get("node_mapping", {}),
+            "summary": data.get("summary", {}),
+            "thinking": data.get("thinking", ""),
+            "actions": actions,
+            "raw_response": data
+        }
+    
+    def evaluate_metrics(self, output: Dict[str, Any], context: AgentContext) -> Dict[str, float]:
+        """Evaluate netlist metrics including simulation"""
+        
+        spice_code = output.get("spice_code", "")
+        components = context.original_input.get("components", [])
+        nodes = context.original_input.get("nodes", [])
+        
+        metrics = {}
+        
+        # Syntax validity - basic checks
+        syntax_score = 0.0
+        if spice_code:
+            # Check for required elements
+            has_end = ".end" in spice_code.lower()
+            has_ground = " 0 " in spice_code or "\t0\t" in spice_code
+            has_components = any(
+                line.strip() and not line.startswith("*") and not line.startswith(".")
+                for line in spice_code.split("\n")
+                if line.strip()
+            )
+            
+            if has_end:
+                syntax_score += 0.3
+            if has_ground:
+                syntax_score += 0.3
+            if has_components:
+                syntax_score += 0.4
+        
+        metrics["syntax_valid"] = syntax_score
+        
+        # Try simulation
+        sim_result = self._run_simulation(spice_code)
+        metrics["simulation_runs"] = 1.0 if sim_result["success"] else 0.0
+        
+        # Print simulation status
+        if sim_result["success"]:
+            print(f"    ✓ ngspice simulation PASSED")
+            # Extract node voltages if available
+            logs = sim_result.get("logs", "")
+            if "Node" in logs and "Voltage" in logs:
+                print(f"    Node voltages extracted from simulation")
+        else:
+            print(f"    ✗ ngspice simulation FAILED")
+            for err in sim_result.get("errors", []):
+                print(f"      - {err}")
+        
+        # Store simulation info
+        self.netlist_output.simulation_attempted = True
+        self.netlist_output.simulation_successful = sim_result["success"]
+        self.netlist_output.simulation_logs = sim_result.get("logs", "")
+        
+        # Topology preserved - check component count
+        netlist_components = self._count_netlist_components(spice_code)
+        expected_components = len([
+            c for c in components 
+            if (c.type if isinstance(c, ComponentInfo) else c.get("type")) != "Ground"
+        ])
+        
+        if expected_components > 0:
+            match_ratio = min(netlist_components, expected_components) / expected_components
+            metrics["topology_preserved"] = match_ratio
+        else:
+            metrics["component_match"] = 0.5
+
+        # Log analysis
+        if missing_core:
+            print(f"    ⚠ Missing core components: {missing_core}")
+        if duplicate_set:
+            print(f"    ⚠ Duplicate components: {duplicate_set}")
+        if extra_core:
+            print(f"    ⚠ Extra non-scaffolding components: {extra_core}")
+        if netlist_scaffolding:
+            print(f"    ✓ Scaffolding elements (allowed): {netlist_scaffolding}")
+
+        # 3. Node match - check for required structural nodes by name
+        # Ground (node 0) and at least one power/signal node must be present.
+        # Count-based matching was unreliable: the CV node list is noisy and never
+        # passed into agent2_input, so expected_nodes was always 0 (always 0.5).
+        netlist_nodes = self._extract_netlist_nodes(spice_code)
+        netlist_nodes_lower = {n.lower() for n in netlist_nodes}
+
+        has_ground = "0" in netlist_nodes
+        power_names = {"vdd", "vcc", "vss", "vee", "avdd", "dvdd", "v+", "v-"}
+        has_power = bool(netlist_nodes_lower & power_names)
+
+        if has_ground and has_power:
+            metrics["node_match"] = 1.0
+        elif has_ground or has_power:
+            metrics["node_match"] = 0.7
+        else:
+            metrics["node_match"] = 0.3
+
+
+        return metrics
+    
+    def build_error_context(
+        self,
+        output: Dict[str, Any],
+        metrics: Dict[str, float],
+        context: AgentContext
+    ) -> AgentContext:
+        """Build error context for next iteration"""
+        
+        new_context = AgentContext(
+            original_input=context.original_input
+        )
+        
+        errors = []
+        feedback_parts = []
+        
+        # Check syntax
+        if metrics.get("syntax_valid", 1.0) < 1.0:
+            spice_code = output.get("spice_code", "")
+            if ".end" not in spice_code.lower():
+                errors.append("Missing .END directive at end of netlist")
+            if " 0 " not in spice_code:
+                errors.append("Ground node '0' not found in any component connection")
+            feedback_parts.append(
+                "Ensure netlist has proper SPICE format with .END directive and ground node 0."
+            )
+        
+        # Check simulation
+        if metrics.get("simulation_runs", 1.0) < 1.0:
+            sim_logs = self.netlist_output.simulation_logs
+            if sim_logs:
+                # Extract key error messages
+                error_lines = [
+                    line for line in sim_logs.split("\n")
+                    if "error" in line.lower() or "fatal" in line.lower()
+                ][:5]
+                for line in error_lines:
+                    errors.append(f"ngspice: {line}")
+            errors.append("Simulation failed - check syntax and ensure DC path to ground")
+
+        # Check component match - use detailed analysis from evaluate_metrics
+        if metrics.get("component_match", 1.0) < 0.95:
+            analysis = getattr(self, '_component_analysis', {})
+
+            missing = analysis.get("missing_core", set())
+            duplicates = analysis.get("duplicates", set())
+            extra = analysis.get("extra_core", set())
+
+            if missing:
+                errors.append(f"MISSING COMPONENTS (must add): {', '.join(sorted(missing))}")
+
+            if duplicates:
+                errors.append(f"DUPLICATE COMPONENTS (remove duplicates): {', '.join(sorted(duplicates))}")
+
+            if extra:
+                errors.append(f"EXTRA COMPONENTS not in validated list: {', '.join(sorted(extra))} "
+                            f"(use scaffolding prefixes like VSUP_, VB_, RSHUNT_ if needed)")
+
+            if not (missing or duplicates or extra):
+                errors.append(f"Component match below threshold - verify all validated components appear exactly once")
+
+        # Check node match
+        if metrics.get("node_match", 1.0) < 0.90:
+            errors.append(
+                "Missing required structural nodes: ensure ground (node 0) and at least one "
+                "power rail (vdd/vcc/vss) are present in the netlist."
+            )
+
+
+        new_context.errors = errors
+        new_context.feedback = "\n".join(feedback_parts)
+        
+        return new_context
+    
+    def _run_simulation(self, spice_code: str) -> Dict[str, Any]:
+        """Run ngspice simulation on the netlist"""
+        
+        result = {
+            "success": False,
+            "logs": "",
+            "errors": []
+        }
+        
+        if not spice_code:
+            result["errors"].append("Empty netlist")
+            return result
+        
+        try:
+            # Write to temp file
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.sp', delete=False) as f:
+                f.write(spice_code)
+                temp_path = f.name
+            
+            # Run ngspice in batch mode
+            cmd = ["ngspice", "-b", temp_path]
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            
+            result["logs"] = proc.stdout + proc.stderr
+            
+            # Check for success
+            if proc.returncode == 0:
+                # Also check for error messages in output
+                if "error" not in proc.stdout.lower() and "error" not in proc.stderr.lower():
+                    result["success"] = True
+                else:
+                    result["errors"].append("Simulation reported errors")
+            else:
+                result["errors"].append(f"ngspice returned code {proc.returncode}")
+            
+            # Cleanup
+            os.unlink(temp_path)
+            
+        except subprocess.TimeoutExpired:
+            result["errors"].append("Simulation timed out")
+        except FileNotFoundError:
+            # ngspice not installed - assume success for syntax check only
+            result["success"] = True
+            result["logs"] = "ngspice not found - skipping simulation"
+        except Exception as e:
+            result["errors"].append(str(e))
+        
+        return result
+    
+    def _count_netlist_components(self, spice_code: str) -> int:
+        """Count components in SPICE netlist"""
+        count = 0
+        for line in spice_code.split("\n"):
+            line = line.strip()
+            if line and not line.startswith("*") and not line.startswith("."):
+                # Component line
+                if line[0].upper() in "RCLMQVID":
+                    count += 1
+        return count
+    
+    def _extract_netlist_nodes(self, spice_code: str) -> set:
+        """Extract node names from SPICE netlist"""
+        nodes = set()
+        for line in spice_code.split("\n"):
+            line = line.strip()
+            if line and not line.startswith("*") and not line.startswith("."):
+                parts = line.split()
+                if len(parts) >= 3:
+                    # Extract node names (usually positions 1, 2, sometimes 3, 4)
+                    for part in parts[1:5]:
+                        # Skip values and model names
+                        if not any(c.isalpha() and c not in "abcdefABCDEFxX" for c in part):
+                            if not part.replace(".", "").replace("-", "").replace("+", "").isdigit():
+                                nodes.add(part)
+                        elif part.isalnum():
+                            nodes.add(part)
+        return nodes
+    
+    def _get_metric_weights(self) -> Dict[str, float]:
+        return self.config.metric_weights.agent3_weights
+    
+    def _get_metric_target(self, metric: str) -> float:
+        targets = {
+            "syntax_valid": 1.0,
+            "simulation_runs": 1.0,
+            "topology_preserved": 0.95,
+            "component_match": 1.0,
+            "node_match": 1.0
+        }
+        return targets.get(metric, 0.8)
+    
+    def get_netlist_output(self) -> NetlistOutput:
+        """Get the netlist output object"""
+        return self.netlist_output
+    
+    def _extract_spice_fallback(self, response: str, context: AgentContext) -> Dict[str, Any]:
+        """Try to extract SPICE code directly from response text."""
+        
+        # Look for SPICE-like content
+        spice_code = ""
+        
+        # Try to find code block
+        code_match = re.search(r'```(?:spice|ngspice|netlist)?\s*(.*?)\s*```', response, re.DOTALL | re.IGNORECASE)
+        if code_match:
+            spice_code = code_match.group(1)
+        else:
+            # Look for lines that look like SPICE
+            lines = response.split('\n')
+            spice_lines = []
+            for line in lines:
+                line = line.strip()
+                # SPICE lines typically start with component letters or commands
+                if line and (line[0] in 'RCLMQVIDrclmqvid*.' or line.startswith('.end')):
+                    spice_lines.append(line)
+            
+            if spice_lines:
+                spice_code = '\n'.join(spice_lines)
+        
+        if not spice_code:
+            # Generate minimal SPICE from topology
+            spice_code = self._generate_minimal_spice(context)
+        
+        self.netlist_output.spice_code = spice_code
+        
+        return {
+            "spice_code": spice_code,
+            "netlist": {},
+            "node_mapping": {},
+            "summary": {"fallback": True},
+            "thinking": "Fallback: extracted/generated SPICE directly",
+            "actions": ["FALLBACK: Generated minimal SPICE netlist"],
+            "raw_response": {"fallback": True}
+        }
+    
+    def _generate_minimal_spice(self, context: AgentContext) -> str:
+        """Generate minimal SPICE netlist from topology."""
+        components = context.original_input.get("components", [])
+        
+        lines = ["* Auto-generated minimal netlist", "*"]
+        lines.append("* Components")
+        
+        node_counter = 1
+        for i, comp in enumerate(components):
+            if hasattr(comp, 'type'):
+                comp_type = comp.type
+                comp_id = comp.id
+            else:
+                comp_type = comp.get('type', 'R')
+                comp_id = comp.get('id', f'C{i}')
+            
+            # Generate SPICE line based on type
+            if comp_type in ['Resistor', 'R']:
+                lines.append(f"R{i+1} n{node_counter} n{node_counter+1} 10k")
+                node_counter += 2
+            elif comp_type in ['Capacitor', 'C']:
+                lines.append(f"C{i+1} n{node_counter} 0 1u")
+                node_counter += 1
+            elif comp_type in ['NMOS', 'MOSFET']:
+                lines.append(f"M{i+1} n{node_counter} n{node_counter+1} 0 0 NMOS W=1u L=180n")
+                node_counter += 2
+            elif comp_type in ['PMOS']:
+                lines.append(f"M{i+1} n{node_counter} n{node_counter+1} vdd vdd PMOS W=1u L=180n")
+                node_counter += 2
+            elif comp_type in ['VoltageSource', 'V', 'Voltage_Source']:
+                lines.append(f"V{i+1} vdd 0 1.8")
+            elif comp_type in ['CurrentSource', 'I', 'Current_Source']:
+                lines.append(f"I{i+1} vdd n{node_counter} 10u")
+                node_counter += 1
+        
+        lines.append("*")
+        lines.append("* Power supply")
+        lines.append("VDD vdd 0 1.8")
+        lines.append("*")
+        lines.append("* Models")
+        lines.append(".model NMOS NMOS (VTH0=0.4)")
+        lines.append(".model PMOS PMOS (VTH0=-0.4)")
+        lines.append("*")
+        lines.append(".OP")
+        lines.append(".END")
+        
+        return '\n'.join(lines)
+

--- a/agents_v2/config.py
+++ b/agents_v2/config.py
@@ -1,0 +1,239 @@
+"""
+Configuration for Agents V2 Pipeline
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from enum import Enum
+
+
+class QualityTier(Enum):
+    """Output quality classification"""
+    VERIFIED = "verified"           # Score >= 0.90, all checks passed
+    CONFIDENT = "confident"         # Score 0.80-0.90, minor issues
+    LOW_CONFIDENCE = "low_confidence"  # Score 0.60-0.80, proceed with caution
+    FAILED = "failed"               # Score < 0.60, needs review
+    PARTIAL = "partial"             # Some stages succeeded, others failed
+
+
+class PipelineStatus(Enum):
+    """Overall pipeline status"""
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    NEEDS_REVIEW = "needs_review"
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration for each agent"""
+    
+    # Agent models 
+    # NOTE: GPT-5.2 models may have different API requirements
+    # Set USE_GPT5 = True when ready to use GPT-5.2
+    # For now, default to gpt-4o which is known to work
+    
+    # Production config (when GPT-5.2 is ready):
+    # agent1_model: str = "gpt-5.2"
+    # agent2_model: str = "gpt-5.2"
+    # agent3_model: str = "gpt-5.2"
+    # judge_model: str = "gpt-5.2-pro"
+    
+    # Production config with GPT-5.2:
+    agent1_model: str = "gpt-5.2"           # Component Refinement
+    agent2_model: str = "gpt-5.2"           # Connectivity Refinement
+    agent3_model: str = "gpt-5.2"           # Netlist Generation
+    judge_model: str = "gpt-5.2"            # LLM-as-Judge (mandatory) - same as agents
+    
+    # Fallback models (if primary fails)
+    fallback_model: str = "gpt-4o-mini"
+    
+    # API configuration
+    api_timeout: int = 60
+    max_retries: int = 3
+    
+    # Flag to switch to GPT-5.2 when available
+    use_gpt5: bool = False
+    
+    def get_agent_model(self, agent_num: int) -> str:
+        """Get model for agent, considering GPT-5 flag"""
+        if self.use_gpt5:
+            if agent_num <= 3:
+                return "gpt-5.2"
+            else:
+                return "gpt-5.2-pro"
+        else:
+            models = {1: self.agent1_model, 2: self.agent2_model, 
+                     3: self.agent3_model, 4: self.judge_model}
+            return models.get(agent_num, self.agent1_model)
+
+
+@dataclass
+class ThresholdConfig:
+    """Threshold configuration for each stage"""
+    
+    # Agent 1: Component Refinement
+    agent1_pass_threshold: float = 0.90
+    agent1_acceptable_threshold: float = 0.70
+    agent1_min_viable_threshold: float = 0.50
+    
+    # Agent 2: Connectivity Refinement
+    agent2_pass_threshold: float = 0.90
+    agent2_acceptable_threshold: float = 0.70
+    agent2_min_viable_threshold: float = 0.50
+    
+    # Agent 3: Netlist Generation
+    agent3_pass_threshold: float = 0.95
+    agent3_acceptable_threshold: float = 0.75
+    agent3_min_viable_threshold: float = 0.50
+    
+    # LLM-as-Judge
+    judge_pass_threshold: float = 0.96
+    judge_acceptable_threshold: float = 0.70
+    judge_min_confidence: float = 0.60
+
+
+@dataclass
+class IterationConfig:
+    """Iteration limits for each agent"""
+    
+    agent1_max_iterations: int = 3
+    agent2_max_iterations: int = 3
+    agent3_max_iterations: int = 3
+    judge_max_retries: int = 2
+    
+    # Early stopping
+    min_improvement_threshold: float = 0.02  # Stop if improvement < 2%
+    stuck_iterations_limit: int = 2  # Stop if no improvement for N iterations
+
+
+@dataclass
+class MetricWeights:
+    """Weights for combining metrics into scores"""
+    
+    # Agent 1 metric weights
+    agent1_weights: Dict[str, float] = field(default_factory=lambda: {
+        "refinement_activity": 0.10,
+        "component_coverage": 0.15,
+        "terminal_completeness": 0.35,
+        "type_confidence": 0.20,
+        "visual_grounding": 0.20
+    })
+    
+    # Agent 2 metric weights
+    agent2_weights: Dict[str, float] = field(default_factory=lambda: {
+        "wire_filtering": 0.15,
+        "connection_completeness": 0.30,
+        "node_validity": 0.20,
+        "electrical_validity": 0.20,
+        "visual_grounding": 0.15
+    })
+    
+    # Agent 3 metric weights
+    agent3_weights: Dict[str, float] = field(default_factory=lambda: {
+        "syntax_valid": 0.25,
+        "simulation_runs": 0.30,
+        "topology_preserved": 0.25,
+        "component_match": 0.10,
+        "node_match": 0.10
+    })
+
+
+@dataclass
+class DifficultyConfig:
+    """Configuration for difficulty scoring"""
+    
+    # EMA decay factor for curriculum learning
+    ema_decay: float = 0.9
+    
+    # Difficulty factor weights
+    factor_weights: Dict[str, float] = field(default_factory=lambda: {
+        "component_count": 0.10,
+        "component_density": 0.10,
+        "wire_density": 0.10,
+        "crossing_count": 0.15,
+        "yolo_miss_rate": 0.15,
+        "yolo_fp_rate": 0.10,
+        "agent_iterations": 0.15,
+        "image_quality": 0.05,
+        "line_noise_ratio": 0.10
+    })
+    
+    # Curriculum stage thresholds
+    stage_thresholds: List[float] = field(default_factory=lambda: [
+        0.2,  # Stage 1: easiest (difficulty < 0.2)
+        0.4,  # Stage 2: easy
+        0.6,  # Stage 3: medium
+        0.8,  # Stage 4: hard
+        1.0   # Stage 5: hardest
+    ])
+
+
+@dataclass
+class ExportConfig:
+    """Configuration for training data export"""
+    
+    # Export formats
+    export_yolo: bool = True
+    export_coco: bool = True
+    export_custom: bool = True
+    
+    # YOLO class mapping
+    component_classes: Dict[str, int] = field(default_factory=lambda: {
+        "Resistor": 0,
+        "Capacitor": 1,
+        "Inductor": 2,
+        "NMOS": 3,
+        "PMOS": 4,
+        "NPN": 5,
+        "PNP": 6,
+        "Diode": 7,
+        "VoltageSource": 8,
+        "CurrentSource": 9,
+        "Ground": 10,
+        "OpAmp": 11,
+        "Other": 12
+    })
+    
+    # Wire segment classes
+    wire_classes: Dict[str, int] = field(default_factory=lambda: {
+        "wire": 0,
+        "component_internal": 1,
+        "noise": 2,
+        "text": 3
+    })
+    
+    # Node classes
+    node_classes: Dict[str, int] = field(default_factory=lambda: {
+        "junction": 0,
+        "crossing": 1,
+        "terminal": 2,
+        "corner": 3
+    })
+
+
+@dataclass
+class PipelineConfig:
+    """Complete pipeline configuration"""
+    
+    models: ModelConfig = field(default_factory=ModelConfig)
+    thresholds: ThresholdConfig = field(default_factory=ThresholdConfig)
+    iterations: IterationConfig = field(default_factory=IterationConfig)
+    metric_weights: MetricWeights = field(default_factory=MetricWeights)
+    difficulty: DifficultyConfig = field(default_factory=DifficultyConfig)
+    export: ExportConfig = field(default_factory=ExportConfig)
+    
+    # Pipeline behavior
+    continue_on_failure: bool = True  # Always continue with best output
+    collect_training_data: bool = True
+    save_intermediate_outputs: bool = True
+    verbose: bool = True
+    
+    # Output paths
+    output_dir: str = "agents_v2_output"
+    training_data_dir: str = "training_data"
+
+
+# Default configuration instance
+DEFAULT_CONFIG = PipelineConfig()
+

--- a/agents_v2/models/__init__.py
+++ b/agents_v2/models/__init__.py
@@ -1,0 +1,47 @@
+"""
+Data models for Agents V2 Pipeline
+"""
+
+from .components import (
+    Point, BoundingBox, LineSegment,
+    TerminalInfo, ComponentInfo
+)
+from .wires import (
+    WireInfo, SegmentAnnotation, JunctionInfo
+)
+from .nodes import (
+    NodeInfo, GraphNode, GraphEdge, TopologyAnnotation
+)
+from .difficulty import (
+    DifficultyFactors, DifficultyScores
+)
+from .training_data import (
+    ComponentAnnotation, WireAnnotation, NodeAnnotation,
+    TerminalAnnotation, RefinementDeltas, ChangeLogEntry,
+    TrainingDataSample
+)
+from .output import (
+    StageResult, IterationRecord, RawCVOutput,
+    NetlistOutput, PipelineOutput
+)
+
+__all__ = [
+    # Basic types
+    "Point", "BoundingBox", "LineSegment",
+    # Components
+    "TerminalInfo", "ComponentInfo",
+    # Wires
+    "WireInfo", "SegmentAnnotation", "JunctionInfo",
+    # Nodes
+    "NodeInfo", "GraphNode", "GraphEdge", "TopologyAnnotation",
+    # Difficulty
+    "DifficultyFactors", "DifficultyScores",
+    # Training data
+    "ComponentAnnotation", "WireAnnotation", "NodeAnnotation",
+    "TerminalAnnotation", "RefinementDeltas", "ChangeLogEntry",
+    "TrainingDataSample",
+    # Output
+    "StageResult", "IterationRecord", "RawCVOutput",
+    "NetlistOutput", "PipelineOutput"
+]
+

--- a/agents_v2/models/components.py
+++ b/agents_v2/models/components.py
@@ -1,0 +1,253 @@
+"""
+Component-related data models with spatial information
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Tuple
+import math
+
+
+@dataclass
+class Point:
+    """2D point in pixel coordinates"""
+    x: int
+    y: int
+    
+    def to_normalized(self, img_width: int, img_height: int) -> Tuple[float, float]:
+        """Convert to normalized coordinates (0-1)"""
+        return (self.x / img_width, self.y / img_height)
+    
+    def distance_to(self, other: 'Point') -> float:
+        """Euclidean distance to another point"""
+        return math.sqrt((self.x - other.x)**2 + (self.y - other.y)**2)
+    
+    def to_dict(self) -> Dict:
+        return {"x": self.x, "y": self.y}
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'Point':
+        return cls(x=d["x"], y=d["y"])
+
+
+@dataclass
+class BoundingBox:
+    """Bounding box in pixel coordinates"""
+    x_min: int
+    y_min: int
+    x_max: int
+    y_max: int
+    
+    @property
+    def width(self) -> int:
+        return self.x_max - self.x_min
+    
+    @property
+    def height(self) -> int:
+        return self.y_max - self.y_min
+    
+    @property
+    def area(self) -> int:
+        return self.width * self.height
+    
+    @property
+    def center(self) -> Point:
+        return Point(
+            x=(self.x_min + self.x_max) // 2,
+            y=(self.y_min + self.y_max) // 2
+        )
+    
+    def to_yolo_format(self, img_width: int, img_height: int) -> Tuple[float, float, float, float]:
+        """Convert to YOLO format (x_center, y_center, width, height) normalized"""
+        x_center = (self.x_min + self.x_max) / 2 / img_width
+        y_center = (self.y_min + self.y_max) / 2 / img_height
+        width = self.width / img_width
+        height = self.height / img_height
+        return (x_center, y_center, width, height)
+    
+    def to_coco_format(self) -> Tuple[int, int, int, int]:
+        """Convert to COCO format (x, y, width, height) in pixels"""
+        return (self.x_min, self.y_min, self.width, self.height)
+    
+    def contains_point(self, point: Point) -> bool:
+        """Check if point is inside bounding box"""
+        return (self.x_min <= point.x <= self.x_max and 
+                self.y_min <= point.y <= self.y_max)
+    
+    def iou(self, other: 'BoundingBox') -> float:
+        """Calculate Intersection over Union with another bbox"""
+        x_min = max(self.x_min, other.x_min)
+        y_min = max(self.y_min, other.y_min)
+        x_max = min(self.x_max, other.x_max)
+        y_max = min(self.y_max, other.y_max)
+        
+        if x_min >= x_max or y_min >= y_max:
+            return 0.0
+        
+        intersection = (x_max - x_min) * (y_max - y_min)
+        union = self.area + other.area - intersection
+        return intersection / union if union > 0 else 0.0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "x_min": self.x_min,
+            "y_min": self.y_min,
+            "x_max": self.x_max,
+            "y_max": self.y_max
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'BoundingBox':
+        return cls(
+            x_min=d["x_min"],
+            y_min=d["y_min"],
+            x_max=d["x_max"],
+            y_max=d["y_max"]
+        )
+
+
+@dataclass
+class LineSegment:
+    """Straight line segment"""
+    start: Point
+    end: Point
+    
+    @property
+    def length(self) -> float:
+        return self.start.distance_to(self.end)
+    
+    @property
+    def angle(self) -> float:
+        """Angle in degrees from horizontal"""
+        dx = self.end.x - self.start.x
+        dy = self.end.y - self.start.y
+        return math.degrees(math.atan2(dy, dx))
+    
+    @property
+    def is_horizontal(self) -> bool:
+        """Within 10 degrees of horizontal"""
+        return abs(self.angle) < 10 or abs(self.angle) > 170
+    
+    @property
+    def is_vertical(self) -> bool:
+        """Within 10 degrees of vertical"""
+        angle = abs(self.angle)
+        return 80 < angle < 100
+    
+    @property
+    def midpoint(self) -> Point:
+        return Point(
+            x=(self.start.x + self.end.x) // 2,
+            y=(self.start.y + self.end.y) // 2
+        )
+    
+    def to_dict(self) -> Dict:
+        return {
+            "start": self.start.to_dict(),
+            "end": self.end.to_dict()
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'LineSegment':
+        return cls(
+            start=Point.from_dict(d["start"]),
+            end=Point.from_dict(d["end"])
+        )
+
+
+@dataclass
+class TerminalInfo:
+    """Terminal/pin information with position"""
+    
+    name: str                        # "pin1", "drain", "gate", etc.
+    position: Point                  # Pixel coordinates
+    connected_to_node: str = ""      # Node this terminal connects to
+    connected_via_wire: Optional[str] = None  # Wire ID if applicable
+    
+    def to_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "position": self.position.to_dict(),
+            "connected_to_node": self.connected_to_node,
+            "connected_via_wire": self.connected_via_wire
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'TerminalInfo':
+        return cls(
+            name=d["name"],
+            position=Point.from_dict(d["position"]),
+            connected_to_node=d.get("connected_to_node", ""),
+            connected_via_wire=d.get("connected_via_wire")
+        )
+
+
+@dataclass
+class ComponentInfo:
+    """Detailed component information with spatial data"""
+    
+    # Identity
+    id: str                          # "R1", "M1", etc.
+    type: str                        # "Resistor", "NMOS", "PMOS", etc.
+    value: Optional[str] = None      # "10k", "1u", etc.
+    
+    # Spatial (pixel coordinates)
+    bbox: Optional[BoundingBox] = None
+    center: Optional[Point] = None
+    orientation: str = "horizontal"  # "horizontal", "vertical", "diagonal"
+    
+    # Terminals with positions
+    terminals: List[TerminalInfo] = field(default_factory=list)
+    
+    # Refinement info
+    source: str = "yolo"             # "yolo", "agent_added", "agent_corrected"
+    original_detection: Optional[Dict] = None  # Original YOLO detection
+    confidence: float = 0.0
+    refinement_notes: str = ""       # What agent did to this component
+    
+    # Connection info (derived)
+    connected_nodes: Dict[str, str] = field(default_factory=dict)  # {terminal: node}
+    
+    def get_terminal(self, name: str) -> Optional[TerminalInfo]:
+        """Get terminal by name"""
+        for terminal in self.terminals:
+            if terminal.name == name:
+                return terminal
+        return None
+    
+    def get_connected_nodes(self) -> List[str]:
+        """Get list of all connected nodes"""
+        return list(set(t.connected_to_node for t in self.terminals if t.connected_to_node))
+    
+    def to_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "value": self.value,
+            "bbox": self.bbox.to_dict() if self.bbox else None,
+            "center": self.center.to_dict() if self.center else None,
+            "orientation": self.orientation,
+            "terminals": [t.to_dict() for t in self.terminals],
+            "source": self.source,
+            "original_detection": self.original_detection,
+            "confidence": self.confidence,
+            "refinement_notes": self.refinement_notes,
+            "connected_nodes": self.connected_nodes
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'ComponentInfo':
+        return cls(
+            id=d["id"],
+            type=d["type"],
+            value=d.get("value"),
+            bbox=BoundingBox.from_dict(d["bbox"]) if d.get("bbox") else None,
+            center=Point.from_dict(d["center"]) if d.get("center") else None,
+            orientation=d.get("orientation", "horizontal"),
+            terminals=[TerminalInfo.from_dict(t) for t in d.get("terminals", [])],
+            source=d.get("source", "yolo"),
+            original_detection=d.get("original_detection"),
+            confidence=d.get("confidence", 0.0),
+            refinement_notes=d.get("refinement_notes", ""),
+            connected_nodes=d.get("connected_nodes", {})
+        )
+

--- a/agents_v2/models/difficulty.py
+++ b/agents_v2/models/difficulty.py
@@ -1,0 +1,254 @@
+"""
+Difficulty scoring for curriculum learning
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import math
+
+
+@dataclass
+class DifficultyFactors:
+    """Factors that contribute to sample difficulty"""
+    
+    # Density factors
+    component_count: int = 0
+    component_density: float = 0.0    # Components per 1000 sq pixels
+    wire_count: int = 0
+    wire_density: float = 0.0
+    junction_count: int = 0
+    
+    # Complexity factors
+    crossing_count: int = 0           # Wire crossings (not junctions)
+    overlapping_components: int = 0   # Components that touch/overlap
+    multi_terminal_components: int = 0  # Components with >2 terminals (MOSFETs, etc.)
+    
+    # Noise/quality factors
+    image_quality_score: float = 1.0  # 0-1, lower = worse quality
+    ocr_text_density: float = 0.0     # Amount of text in image
+    line_noise_ratio: float = 0.0     # Hough noise lines / total lines
+    
+    # Detection difficulty (from CV performance)
+    yolo_avg_confidence: float = 0.0  # Higher = easier
+    yolo_miss_rate: float = 0.0       # Agent additions / final count
+    yolo_fp_rate: float = 0.0         # Agent rejections / yolo count
+    
+    # Connectivity difficulty
+    avg_node_degree: float = 0.0      # Higher = more complex
+    max_node_degree: int = 0
+    floating_terminals_before: int = 0  # Before agent refinement
+    
+    # Agent effort (proxy for difficulty)
+    agent1_iterations: int = 1
+    agent2_iterations: int = 1
+    agent3_iterations: int = 1
+    total_llm_calls: int = 0
+    
+    # Refinement metrics
+    components_added: int = 0
+    components_rejected: int = 0
+    wires_filtered: int = 0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "component_count": self.component_count,
+            "component_density": self.component_density,
+            "wire_count": self.wire_count,
+            "wire_density": self.wire_density,
+            "junction_count": self.junction_count,
+            "crossing_count": self.crossing_count,
+            "overlapping_components": self.overlapping_components,
+            "multi_terminal_components": self.multi_terminal_components,
+            "image_quality_score": self.image_quality_score,
+            "ocr_text_density": self.ocr_text_density,
+            "line_noise_ratio": self.line_noise_ratio,
+            "yolo_avg_confidence": self.yolo_avg_confidence,
+            "yolo_miss_rate": self.yolo_miss_rate,
+            "yolo_fp_rate": self.yolo_fp_rate,
+            "avg_node_degree": self.avg_node_degree,
+            "max_node_degree": self.max_node_degree,
+            "floating_terminals_before": self.floating_terminals_before,
+            "agent1_iterations": self.agent1_iterations,
+            "agent2_iterations": self.agent2_iterations,
+            "agent3_iterations": self.agent3_iterations,
+            "total_llm_calls": self.total_llm_calls,
+            "components_added": self.components_added,
+            "components_rejected": self.components_rejected,
+            "wires_filtered": self.wires_filtered
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'DifficultyFactors':
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class DifficultyScores:
+    """Multi-dimensional difficulty scoring for curriculum learning"""
+    
+    # Overall difficulty (weighted combination)
+    overall_difficulty: float = 0.0   # 0.0 (easy) to 1.0 (hard)
+    
+    # Per-task difficulty
+    component_difficulty: float = 0.0  # How hard is component detection?
+    wire_difficulty: float = 0.0       # How hard is wire detection/tracing?
+    node_difficulty: float = 0.0       # How hard is node detection?
+    topology_difficulty: float = 0.0   # How hard is understanding connections?
+    
+    # Curriculum stage assignment
+    curriculum_stage: int = 1          # 1 (easiest) to 5 (hardest)
+    
+    # EMA tracking (updated during training)
+    ema_loss_component: Optional[float] = None
+    ema_loss_wire: Optional[float] = None
+    ema_loss_node: Optional[float] = None
+    ema_loss_overall: Optional[float] = None
+    
+    # Raw factors
+    factors: Optional[DifficultyFactors] = None
+    
+    @classmethod
+    def compute(cls, factors: DifficultyFactors, 
+                weights: Optional[Dict[str, float]] = None,
+                stage_thresholds: Optional[List[float]] = None) -> 'DifficultyScores':
+        """Compute difficulty scores from factors"""
+        
+        if weights is None:
+            weights = {
+                "component_count": 0.08,
+                "component_density": 0.08,
+                "wire_density": 0.08,
+                "crossing_count": 0.10,
+                "yolo_miss_rate": 0.12,
+                "yolo_fp_rate": 0.08,
+                "agent_iterations": 0.15,
+                "line_noise_ratio": 0.10,
+                "floating_terminals": 0.08,
+                "multi_terminal": 0.08,
+                "image_quality": 0.05
+            }
+        
+        if stage_thresholds is None:
+            stage_thresholds = [0.2, 0.4, 0.6, 0.8, 1.0]
+        
+        # Compute component difficulty
+        component_diff = cls._normalize(
+            factors.component_count * 0.3 +
+            factors.yolo_miss_rate * 30 +
+            factors.yolo_fp_rate * 20 +
+            (1 - factors.yolo_avg_confidence) * 10 +
+            factors.multi_terminal_components * 0.5
+        )
+        
+        # Compute wire difficulty
+        wire_diff = cls._normalize(
+            factors.wire_count * 0.1 +
+            factors.line_noise_ratio * 30 +
+            factors.crossing_count * 2 +
+            factors.wires_filtered * 0.2
+        )
+        
+        # Compute node difficulty
+        node_diff = cls._normalize(
+            factors.junction_count * 0.3 +
+            factors.crossing_count * 1.5 +
+            factors.floating_terminals_before * 2 +
+            factors.avg_node_degree * 0.5
+        )
+        
+        # Compute topology difficulty
+        topo_diff = cls._normalize(
+            factors.component_count * 0.2 +
+            factors.avg_node_degree * 1.0 +
+            factors.max_node_degree * 0.3 +
+            factors.crossing_count * 1.0 +
+            (factors.agent1_iterations + factors.agent2_iterations) * 0.3
+        )
+        
+        # Overall difficulty (weighted average)
+        overall = (
+            component_diff * 0.30 +
+            wire_diff * 0.25 +
+            node_diff * 0.20 +
+            topo_diff * 0.25
+        )
+        
+        # Add penalty for agent effort
+        agent_effort = (
+            factors.agent1_iterations + 
+            factors.agent2_iterations + 
+            factors.agent3_iterations
+        ) / 9.0  # Normalize by max (3+3+3)
+        overall = min(1.0, overall + agent_effort * 0.15)
+        
+        # Determine curriculum stage
+        stage = 1
+        for i, threshold in enumerate(stage_thresholds):
+            if overall <= threshold:
+                stage = i + 1
+                break
+        
+        return cls(
+            overall_difficulty=overall,
+            component_difficulty=component_diff,
+            wire_difficulty=wire_diff,
+            node_difficulty=node_diff,
+            topology_difficulty=topo_diff,
+            curriculum_stage=stage,
+            factors=factors
+        )
+    
+    @staticmethod
+    def _normalize(value: float, max_value: float = 20.0) -> float:
+        """Normalize a value to 0-1 range using sigmoid-like function"""
+        return 1.0 / (1.0 + math.exp(-value / max_value * 4 + 2))
+    
+    def update_ema(self, loss_component: float, loss_wire: float, 
+                   loss_node: float, decay: float = 0.9):
+        """Update EMA loss values during training"""
+        if self.ema_loss_component is None:
+            self.ema_loss_component = loss_component
+            self.ema_loss_wire = loss_wire
+            self.ema_loss_node = loss_node
+        else:
+            self.ema_loss_component = decay * self.ema_loss_component + (1 - decay) * loss_component
+            self.ema_loss_wire = decay * self.ema_loss_wire + (1 - decay) * loss_wire
+            self.ema_loss_node = decay * self.ema_loss_node + (1 - decay) * loss_node
+        
+        self.ema_loss_overall = (
+            self.ema_loss_component * 0.4 +
+            self.ema_loss_wire * 0.3 +
+            self.ema_loss_node * 0.3
+        )
+    
+    def to_dict(self) -> Dict:
+        return {
+            "overall_difficulty": self.overall_difficulty,
+            "component_difficulty": self.component_difficulty,
+            "wire_difficulty": self.wire_difficulty,
+            "node_difficulty": self.node_difficulty,
+            "topology_difficulty": self.topology_difficulty,
+            "curriculum_stage": self.curriculum_stage,
+            "ema_loss_component": self.ema_loss_component,
+            "ema_loss_wire": self.ema_loss_wire,
+            "ema_loss_node": self.ema_loss_node,
+            "ema_loss_overall": self.ema_loss_overall,
+            "factors": self.factors.to_dict() if self.factors else None
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'DifficultyScores':
+        return cls(
+            overall_difficulty=d.get("overall_difficulty", 0.0),
+            component_difficulty=d.get("component_difficulty", 0.0),
+            wire_difficulty=d.get("wire_difficulty", 0.0),
+            node_difficulty=d.get("node_difficulty", 0.0),
+            topology_difficulty=d.get("topology_difficulty", 0.0),
+            curriculum_stage=d.get("curriculum_stage", 1),
+            ema_loss_component=d.get("ema_loss_component"),
+            ema_loss_wire=d.get("ema_loss_wire"),
+            ema_loss_node=d.get("ema_loss_node"),
+            ema_loss_overall=d.get("ema_loss_overall"),
+            factors=DifficultyFactors.from_dict(d["factors"]) if d.get("factors") else None
+        )
+

--- a/agents_v2/models/nodes.py
+++ b/agents_v2/models/nodes.py
@@ -1,0 +1,310 @@
+"""
+Node and topology graph data models
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Tuple, Any
+from .components import Point, BoundingBox
+import json
+
+
+@dataclass
+class NodeInfo:
+    """Electrical node information with spatial data"""
+    
+    id: str                          # "VDD", "0", "node_1", etc.
+    type: str = "internal"           # "power", "ground", "signal", "internal"
+    
+    # Spatial extent
+    positions: List[Point] = field(default_factory=list)  # All points where node exists
+    
+    # Connectivity
+    connected_terminals: List[str] = field(default_factory=list)  # ["R1.pin1", "M1.drain"]
+    connected_wires: List[str] = field(default_factory=list)  # ["W1", "W5"]
+    
+    # Electrical properties
+    is_power: bool = False
+    is_ground: bool = False
+    voltage_label: Optional[str] = None  # "VDD", "5V", etc.
+    
+    # Confidence
+    confidence: float = 0.0
+    source: str = "agent_identified"
+    
+    @property
+    def degree(self) -> int:
+        """Number of connections"""
+        return len(self.connected_terminals)
+    
+    @property
+    def centroid(self) -> Optional[Point]:
+        """Average position of all node points"""
+        if not self.positions:
+            return None
+        x = sum(p.x for p in self.positions) // len(self.positions)
+        y = sum(p.y for p in self.positions) // len(self.positions)
+        return Point(x=x, y=y)
+    
+    @property
+    def bounding_region(self) -> Optional[BoundingBox]:
+        """Bounding box of all node points"""
+        if not self.positions:
+            return None
+        x_coords = [p.x for p in self.positions]
+        y_coords = [p.y for p in self.positions]
+        return BoundingBox(
+            x_min=min(x_coords),
+            y_min=min(y_coords),
+            x_max=max(x_coords),
+            y_max=max(y_coords)
+        )
+    
+    def to_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "positions": [p.to_dict() for p in self.positions],
+            "connected_terminals": self.connected_terminals,
+            "connected_wires": self.connected_wires,
+            "is_power": self.is_power,
+            "is_ground": self.is_ground,
+            "voltage_label": self.voltage_label,
+            "confidence": self.confidence,
+            "source": self.source,
+            "degree": self.degree,
+            "centroid": self.centroid.to_dict() if self.centroid else None
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'NodeInfo':
+        return cls(
+            id=d["id"],
+            type=d.get("type", "internal"),
+            positions=[Point.from_dict(p) for p in d.get("positions", [])],
+            connected_terminals=d.get("connected_terminals", []),
+            connected_wires=d.get("connected_wires", []),
+            is_power=d.get("is_power", False),
+            is_ground=d.get("is_ground", False),
+            voltage_label=d.get("voltage_label"),
+            confidence=d.get("confidence", 0.0),
+            source=d.get("source", "agent_identified")
+        )
+
+
+@dataclass
+class GraphNode:
+    """Node in topology graph for GNN training"""
+    
+    node_id: int
+    node_type: str                    # "component" or "electrical_node"
+    name: str                         # Original name (R1, VDD, etc.)
+    
+    # If component
+    component_id: Optional[str] = None
+    component_type: Optional[str] = None
+    
+    # If electrical node
+    electrical_node_id: Optional[str] = None
+    is_power: bool = False
+    is_ground: bool = False
+    
+    # Features for GNN (can be extended)
+    features: List[float] = field(default_factory=list)
+    
+    # Position for visualization
+    position: Optional[Point] = None
+    
+    def to_dict(self) -> Dict:
+        return {
+            "node_id": self.node_id,
+            "node_type": self.node_type,
+            "name": self.name,
+            "component_id": self.component_id,
+            "component_type": self.component_type,
+            "electrical_node_id": self.electrical_node_id,
+            "is_power": self.is_power,
+            "is_ground": self.is_ground,
+            "features": self.features,
+            "position": self.position.to_dict() if self.position else None
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'GraphNode':
+        return cls(
+            node_id=d["node_id"],
+            node_type=d["node_type"],
+            name=d["name"],
+            component_id=d.get("component_id"),
+            component_type=d.get("component_type"),
+            electrical_node_id=d.get("electrical_node_id"),
+            is_power=d.get("is_power", False),
+            is_ground=d.get("is_ground", False),
+            features=d.get("features", []),
+            position=Point.from_dict(d["position"]) if d.get("position") else None
+        )
+
+
+@dataclass
+class GraphEdge:
+    """Edge in topology graph"""
+    
+    source: int                       # Source node ID
+    target: int                       # Target node ID
+    edge_type: str = "connection"     # "connection", "terminal", etc.
+    
+    # Edge attributes
+    attributes: Dict[str, Any] = field(default_factory=dict)
+    
+    # For training
+    weight: float = 1.0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "source": self.source,
+            "target": self.target,
+            "edge_type": self.edge_type,
+            "attributes": self.attributes,
+            "weight": self.weight
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'GraphEdge':
+        return cls(
+            source=d["source"],
+            target=d["target"],
+            edge_type=d.get("edge_type", "connection"),
+            attributes=d.get("attributes", {}),
+            weight=d.get("weight", 1.0)
+        )
+
+
+@dataclass
+class TopologyAnnotation:
+    """Graph structure for GNN training"""
+    
+    # Node list (components + electrical nodes)
+    graph_nodes: List[GraphNode] = field(default_factory=list)
+    
+    # Edge list
+    graph_edges: List[GraphEdge] = field(default_factory=list)
+    
+    # Mappings
+    name_to_id: Dict[str, int] = field(default_factory=dict)
+    id_to_name: Dict[int, str] = field(default_factory=dict)
+    
+    # Statistics
+    num_components: int = 0
+    num_electrical_nodes: int = 0
+    num_edges: int = 0
+    
+    def add_component_node(self, component_id: str, component_type: str, 
+                           position: Optional[Point] = None) -> int:
+        """Add a component node to the graph"""
+        node_id = len(self.graph_nodes)
+        node = GraphNode(
+            node_id=node_id,
+            node_type="component",
+            name=component_id,
+            component_id=component_id,
+            component_type=component_type,
+            position=position
+        )
+        self.graph_nodes.append(node)
+        self.name_to_id[component_id] = node_id
+        self.id_to_name[node_id] = component_id
+        self.num_components += 1
+        return node_id
+    
+    def add_electrical_node(self, node_id_str: str, is_power: bool = False,
+                            is_ground: bool = False, position: Optional[Point] = None) -> int:
+        """Add an electrical node to the graph"""
+        graph_node_id = len(self.graph_nodes)
+        node = GraphNode(
+            node_id=graph_node_id,
+            node_type="electrical_node",
+            name=node_id_str,
+            electrical_node_id=node_id_str,
+            is_power=is_power,
+            is_ground=is_ground,
+            position=position
+        )
+        self.graph_nodes.append(node)
+        self.name_to_id[node_id_str] = graph_node_id
+        self.id_to_name[graph_node_id] = node_id_str
+        self.num_electrical_nodes += 1
+        return graph_node_id
+    
+    def add_edge(self, source_name: str, target_name: str, 
+                 edge_type: str = "connection", **attributes) -> Optional[GraphEdge]:
+        """Add an edge between two nodes"""
+        if source_name not in self.name_to_id or target_name not in self.name_to_id:
+            return None
+        
+        edge = GraphEdge(
+            source=self.name_to_id[source_name],
+            target=self.name_to_id[target_name],
+            edge_type=edge_type,
+            attributes=attributes
+        )
+        self.graph_edges.append(edge)
+        self.num_edges += 1
+        return edge
+    
+    def get_adjacency_list(self) -> Dict[int, List[int]]:
+        """Get adjacency list representation"""
+        adj = {i: [] for i in range(len(self.graph_nodes))}
+        for edge in self.graph_edges:
+            adj[edge.source].append(edge.target)
+            adj[edge.target].append(edge.source)  # Undirected
+        return adj
+    
+    def get_adjacency_matrix(self) -> List[List[int]]:
+        """Get adjacency matrix representation"""
+        n = len(self.graph_nodes)
+        matrix = [[0] * n for _ in range(n)]
+        for edge in self.graph_edges:
+            matrix[edge.source][edge.target] = 1
+            matrix[edge.target][edge.source] = 1  # Undirected
+        return matrix
+    
+    def to_networkx_json(self) -> str:
+        """Export to NetworkX-compatible JSON"""
+        data = {
+            "directed": False,
+            "multigraph": False,
+            "graph": {},
+            "nodes": [
+                {"id": n.node_id, **n.to_dict()}
+                for n in self.graph_nodes
+            ],
+            "links": [
+                {"source": e.source, "target": e.target, **e.to_dict()}
+                for e in self.graph_edges
+            ]
+        }
+        return json.dumps(data, indent=2)
+    
+    def to_dict(self) -> Dict:
+        return {
+            "graph_nodes": [n.to_dict() for n in self.graph_nodes],
+            "graph_edges": [e.to_dict() for e in self.graph_edges],
+            "name_to_id": self.name_to_id,
+            "id_to_name": {str(k): v for k, v in self.id_to_name.items()},
+            "num_components": self.num_components,
+            "num_electrical_nodes": self.num_electrical_nodes,
+            "num_edges": self.num_edges
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'TopologyAnnotation':
+        topo = cls(
+            graph_nodes=[GraphNode.from_dict(n) for n in d.get("graph_nodes", [])],
+            graph_edges=[GraphEdge.from_dict(e) for e in d.get("graph_edges", [])],
+            name_to_id=d.get("name_to_id", {}),
+            id_to_name={int(k): v for k, v in d.get("id_to_name", {}).items()},
+            num_components=d.get("num_components", 0),
+            num_electrical_nodes=d.get("num_electrical_nodes", 0),
+            num_edges=d.get("num_edges", 0)
+        )
+        return topo
+

--- a/agents_v2/models/output.py
+++ b/agents_v2/models/output.py
@@ -1,0 +1,308 @@
+"""
+Pipeline output models
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Any
+from datetime import datetime
+
+from .components import ComponentInfo
+from .wires import WireInfo
+from .nodes import NodeInfo, TopologyAnnotation
+from .training_data import TrainingDataSample, RefinementDeltas
+from .difficulty import DifficultyScores
+
+
+@dataclass
+class IterationRecord:
+    """Record of a single iteration"""
+    
+    iteration_number: int
+    metrics: Dict[str, float] = field(default_factory=dict)
+    score: float = 0.0
+    passed: bool = False
+    
+    # What changed
+    actions_taken: List[str] = field(default_factory=list)
+    errors_found: List[str] = field(default_factory=list)
+    feedback_given: str = ""
+    
+    # Context passed to next iteration
+    error_context: Dict[str, Any] = field(default_factory=dict)
+    
+    # Timing
+    duration_seconds: float = 0.0
+    tokens_used: int = 0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "iteration_number": self.iteration_number,
+            "metrics": self.metrics,
+            "score": self.score,
+            "passed": self.passed,
+            "actions_taken": self.actions_taken,
+            "errors_found": self.errors_found,
+            "feedback_given": self.feedback_given,
+            "error_context": self.error_context,
+            "duration_seconds": self.duration_seconds,
+            "tokens_used": self.tokens_used
+        }
+
+
+@dataclass
+class StageResult:
+    """Result from each pipeline stage"""
+    
+    stage_name: str
+    model_used: str
+    iterations: int = 0
+    
+    # Per-iteration history
+    iteration_history: List[IterationRecord] = field(default_factory=list)
+    
+    # Final metrics
+    final_metrics: Dict[str, float] = field(default_factory=dict)
+    final_score: float = 0.0
+    passed: bool = False
+    
+    # Best iteration (may not be last)
+    best_iteration: int = 0
+    best_score: float = 0.0
+    best_output: Optional[Dict] = None
+    
+    # Quality flags
+    needs_review: bool = False
+    review_reasons: List[str] = field(default_factory=list)
+    
+    # Timing
+    total_duration: float = 0.0
+    total_tokens: int = 0
+    
+    def add_iteration(self, record: IterationRecord):
+        """Add an iteration record and update best"""
+        self.iteration_history.append(record)
+        self.iterations = len(self.iteration_history)
+        
+        if record.score > self.best_score:
+            self.best_score = record.score
+            self.best_iteration = record.iteration_number
+    
+    def to_dict(self) -> Dict:
+        return {
+            "stage_name": self.stage_name,
+            "model_used": self.model_used,
+            "iterations": self.iterations,
+            "iteration_history": [r.to_dict() for r in self.iteration_history],
+            "final_metrics": self.final_metrics,
+            "final_score": self.final_score,
+            "passed": self.passed,
+            "best_iteration": self.best_iteration,
+            "best_score": self.best_score,
+            "needs_review": self.needs_review,
+            "review_reasons": self.review_reasons,
+            "total_duration": self.total_duration,
+            "total_tokens": self.total_tokens
+        }
+
+
+@dataclass
+class RawCVOutput:
+    """Preserved raw CV detection output"""
+    
+    # YOLO
+    yolo_detections: List[Dict] = field(default_factory=list)
+    yolo_confidence_threshold: float = 0.25
+    yolo_model: str = ""
+    
+    # Hough
+    hough_lines: List[Dict] = field(default_factory=list)  # {"start": [x,y], "end": [x,y]}
+    hough_threshold: float = 0.7
+    
+    # Junctions
+    junction_candidates: List[Dict] = field(default_factory=list)  # {"x": x, "y": y}
+    
+    # Image info
+    image_width: int = 0
+    image_height: int = 0
+    image_hash: str = ""
+    
+    def to_dict(self) -> Dict:
+        return {
+            "yolo_detections": self.yolo_detections,
+            "yolo_confidence_threshold": self.yolo_confidence_threshold,
+            "yolo_model": self.yolo_model,
+            "hough_lines": self.hough_lines,
+            "hough_threshold": self.hough_threshold,
+            "junction_candidates": self.junction_candidates,
+            "image_width": self.image_width,
+            "image_height": self.image_height,
+            "image_hash": self.image_hash
+        }
+
+
+@dataclass
+class NetlistOutput:
+    """Generated netlist with metadata"""
+    
+    spice_code: str = ""              # Raw SPICE netlist content
+    spice_file_path: str = ""         # Path to saved .sp file
+    python_generator: str = ""        # Python code that generates it
+    
+    # Parsed components (for verification)
+    netlist_components: List[Dict] = field(default_factory=list)
+    netlist_nodes: List[str] = field(default_factory=list)
+    
+    # Simulation info
+    simulation_attempted: bool = False
+    simulation_successful: bool = False
+    simulation_logs: str = ""
+    simulation_time: float = 0.0
+    simulation_results: Optional[Dict] = None  # Node voltages, etc.
+    
+    def to_dict(self) -> Dict:
+        return {
+            "spice_code": self.spice_code,
+            "spice_file_path": self.spice_file_path,
+            "python_generator": self.python_generator,
+            "netlist_components": self.netlist_components,
+            "netlist_nodes": self.netlist_nodes,
+            "simulation_attempted": self.simulation_attempted,
+            "simulation_successful": self.simulation_successful,
+            "simulation_logs": self.simulation_logs,
+            "simulation_time": self.simulation_time,
+            "simulation_results": self.simulation_results
+        }
+
+
+@dataclass
+class PipelineOutput:
+    """Complete output with all spatial and topological information"""
+    
+    # ============= METADATA =============
+    image_path: str
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    pipeline_version: str = "2.0.0"
+    
+    # ============= QUALITY FLAGS =============
+    overall_status: str = "pending"   # SUCCESS | PARTIAL | FAILED
+    quality_tier: str = "pending"     # VERIFIED | CONFIDENT | LOW_CONFIDENCE | FAILED
+    overall_confidence: float = 0.0
+    needs_review: bool = False
+    review_reasons: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    
+    # ============= STAGE RESULTS =============
+    stage_results: Dict[str, StageResult] = field(default_factory=dict)
+    
+    # ============= COMPONENTS (with coordinates) =============
+    components: List[ComponentInfo] = field(default_factory=list)
+    
+    # ============= WIRES (with coordinates) =============
+    wires: List[WireInfo] = field(default_factory=list)
+    
+    # ============= NODES (with positions) =============
+    nodes: List[NodeInfo] = field(default_factory=list)
+    
+    # ============= TOPOLOGY GRAPH =============
+    topology: Optional[TopologyAnnotation] = None
+    
+    # ============= NETLIST =============
+    netlist: Optional[NetlistOutput] = None
+    
+    # ============= RAW CV DATA (preserved) =============
+    raw_cv_output: Optional[RawCVOutput] = None
+    
+    # ============= REFINEMENT TRACKING =============
+    refinement_deltas: Optional[RefinementDeltas] = None
+    
+    # ============= DIFFICULTY SCORES =============
+    difficulty_scores: Optional[DifficultyScores] = None
+    
+    # ============= TRAINING DATA =============
+    training_sample: Optional[TrainingDataSample] = None
+    
+    # ============= TIMING =============
+    total_time: float = 0.0
+    total_llm_calls: int = 0
+    total_tokens: int = 0
+    
+    def get_stage_result(self, stage: str) -> Optional[StageResult]:
+        return self.stage_results.get(stage)
+    
+    def set_stage_result(self, stage: str, result: StageResult):
+        self.stage_results[stage] = result
+        
+        # Update needs_review if any stage needs review
+        if result.needs_review:
+            self.needs_review = True
+            self.review_reasons.extend(result.review_reasons)
+    
+    def compute_overall_status(self):
+        """Compute overall status from stage results"""
+        if not self.stage_results:
+            self.overall_status = "pending"
+            return
+        
+        all_passed = all(r.passed for r in self.stage_results.values())
+        any_passed = any(r.passed for r in self.stage_results.values())
+        
+        if all_passed:
+            self.overall_status = "SUCCESS"
+            if self.overall_confidence >= 0.90:
+                self.quality_tier = "VERIFIED"
+            elif self.overall_confidence >= 0.80:
+                self.quality_tier = "CONFIDENT"
+            else:
+                self.quality_tier = "LOW_CONFIDENCE"
+        elif any_passed:
+            self.overall_status = "PARTIAL"
+            self.quality_tier = "LOW_CONFIDENCE"
+            self.needs_review = True
+        else:
+            self.overall_status = "FAILED"
+            self.quality_tier = "FAILED"
+            self.needs_review = True
+    
+    def to_dict(self) -> Dict:
+        return {
+            "image_path": self.image_path,
+            "timestamp": self.timestamp,
+            "pipeline_version": self.pipeline_version,
+            "overall_status": self.overall_status,
+            "quality_tier": self.quality_tier,
+            "overall_confidence": self.overall_confidence,
+            "needs_review": self.needs_review,
+            "review_reasons": self.review_reasons,
+            "warnings": self.warnings,
+            "errors": self.errors,
+            "stage_results": {k: v.to_dict() for k, v in self.stage_results.items()},
+            "components": [c.to_dict() for c in self.components],
+            "wires": [w.to_dict() for w in self.wires],
+            "nodes": [n.to_dict() for n in self.nodes],
+            "topology": self.topology.to_dict() if self.topology else None,
+            "netlist": self.netlist.to_dict() if self.netlist else None,
+            "raw_cv_output": self.raw_cv_output.to_dict() if self.raw_cv_output else None,
+            "refinement_deltas": self.refinement_deltas.to_dict() if self.refinement_deltas else None,
+            "difficulty_scores": self.difficulty_scores.to_dict() if self.difficulty_scores else None,
+            "training_sample": self.training_sample.to_dict() if self.training_sample else None,
+            "total_time": self.total_time,
+            "total_llm_calls": self.total_llm_calls,
+            "total_tokens": self.total_tokens
+        }
+    
+    def save(self, output_path: str):
+        """Save output to JSON file"""
+        import json
+        with open(output_path, 'w') as f:
+            json.dump(self.to_dict(), f, indent=2)
+    
+    @classmethod
+    def load(cls, input_path: str) -> 'PipelineOutput':
+        """Load output from JSON file"""
+        import json
+        with open(input_path, 'r') as f:
+            data = json.load(f)
+        # Would need full deserialization implementation
+        return cls(image_path=data.get("image_path", ""))
+

--- a/agents_v2/models/training_data.py
+++ b/agents_v2/models/training_data.py
@@ -1,0 +1,444 @@
+"""
+Training data collection models for multi-head YOLO training
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Tuple, Any
+from datetime import datetime
+
+from .components import Point, BoundingBox, ComponentInfo
+from .wires import WireInfo, SegmentAnnotation
+from .nodes import NodeInfo, TopologyAnnotation
+from .difficulty import DifficultyScores, DifficultyFactors
+
+
+@dataclass
+class ComponentAnnotation:
+    """Annotation for component detection head (YOLO format)"""
+    
+    # YOLO-format bbox (normalized 0-1)
+    class_id: int
+    class_name: str
+    x_center: float
+    y_center: float
+    width: float
+    height: float
+    
+    # Additional attributes for multi-task learning
+    confidence: float = 0.0
+    orientation: int = 0              # 0=horizontal, 1=vertical, 2=diagonal
+    value_present: bool = False
+    terminal_count: int = 2
+    
+    # Source tracking
+    source: str = "yolo_confirmed"    # "yolo_confirmed", "agent_added", "agent_corrected"
+    original_bbox: Optional[List[float]] = None
+    correction_type: Optional[str] = None
+    
+    # Difficulty contribution
+    detection_difficulty: float = 0.0
+    
+    def to_yolo_line(self) -> str:
+        """Export as YOLO annotation line"""
+        return f"{self.class_id} {self.x_center:.6f} {self.y_center:.6f} {self.width:.6f} {self.height:.6f}"
+    
+    def to_dict(self) -> Dict:
+        return {
+            "class_id": self.class_id,
+            "class_name": self.class_name,
+            "x_center": self.x_center,
+            "y_center": self.y_center,
+            "width": self.width,
+            "height": self.height,
+            "confidence": self.confidence,
+            "orientation": self.orientation,
+            "value_present": self.value_present,
+            "terminal_count": self.terminal_count,
+            "source": self.source,
+            "original_bbox": self.original_bbox,
+            "correction_type": self.correction_type,
+            "detection_difficulty": self.detection_difficulty
+        }
+
+
+@dataclass
+class WireAnnotation:
+    """Annotation for wire detection head"""
+    
+    # Wire ID
+    wire_id: str
+    
+    # Polyline (normalized coordinates)
+    points: List[Tuple[float, float]] = field(default_factory=list)
+    
+    # Segment-based representation
+    segments: List[SegmentAnnotation] = field(default_factory=list)
+    
+    # Properties
+    is_horizontal: bool = False
+    is_vertical: bool = False
+    is_diagonal: bool = False
+    total_length: float = 0.0
+    bend_count: int = 0
+    
+    # Connectivity
+    start_connection: str = ""
+    end_connection: str = ""
+    electrical_node: str = ""
+    
+    # Source tracking
+    source_hough_ids: List[int] = field(default_factory=list)
+    source: str = "hough_kept"
+    
+    # Difficulty
+    tracing_difficulty: float = 0.0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "wire_id": self.wire_id,
+            "points": self.points,
+            "segments": [s.to_dict() for s in self.segments],
+            "is_horizontal": self.is_horizontal,
+            "is_vertical": self.is_vertical,
+            "is_diagonal": self.is_diagonal,
+            "total_length": self.total_length,
+            "bend_count": self.bend_count,
+            "start_connection": self.start_connection,
+            "end_connection": self.end_connection,
+            "electrical_node": self.electrical_node,
+            "source_hough_ids": self.source_hough_ids,
+            "source": self.source,
+            "tracing_difficulty": self.tracing_difficulty
+        }
+
+
+@dataclass
+class NodeAnnotation:
+    """Annotation for node/junction detection head"""
+    
+    # Position (normalized 0-1)
+    x: float
+    y: float
+    
+    # Properties
+    node_type: str = "junction"       # "junction", "crossing", "terminal", "corner"
+    class_id: int = 0                 # For classification head
+    is_junction: bool = True
+    has_dot: bool = False
+    
+    # Connectivity
+    connected_wire_count: int = 0
+    connected_terminal_count: int = 0
+    electrical_node_id: str = ""
+    
+    # Source
+    source: str = "hough_intersection"
+    
+    # Difficulty
+    classification_difficulty: float = 0.0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "node_type": self.node_type,
+            "class_id": self.class_id,
+            "is_junction": self.is_junction,
+            "has_dot": self.has_dot,
+            "connected_wire_count": self.connected_wire_count,
+            "connected_terminal_count": self.connected_terminal_count,
+            "electrical_node_id": self.electrical_node_id,
+            "source": self.source,
+            "classification_difficulty": self.classification_difficulty
+        }
+
+
+@dataclass
+class TerminalAnnotation:
+    """Annotation for terminal/pin detection head"""
+    
+    # Position (normalized 0-1)
+    x: float
+    y: float
+    
+    # Parent component
+    component_id: str
+    terminal_name: str
+    
+    # Properties
+    terminal_type: str = "signal"     # "power", "signal", "ground"
+    class_id: int = 0
+    
+    # Connection
+    connected_to_node: str = ""
+    connected_via_wire: Optional[str] = None
+    
+    def to_dict(self) -> Dict:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "component_id": self.component_id,
+            "terminal_name": self.terminal_name,
+            "terminal_type": self.terminal_type,
+            "class_id": self.class_id,
+            "connected_to_node": self.connected_to_node,
+            "connected_via_wire": self.connected_via_wire
+        }
+
+
+@dataclass
+class ChangeLogEntry:
+    """Individual change made by agent"""
+    
+    agent: str                        # "agent1", "agent2", "agent3"
+    iteration: int
+    action: str                       # "add", "remove", "modify", "merge", "confirm"
+    target_type: str                  # "component", "wire", "node", "terminal"
+    target_id: str
+    before: Optional[Dict] = None
+    after: Optional[Dict] = None
+    reason: str = ""
+    confidence: float = 0.0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "agent": self.agent,
+            "iteration": self.iteration,
+            "action": self.action,
+            "target_type": self.target_type,
+            "target_id": self.target_id,
+            "before": self.before,
+            "after": self.after,
+            "reason": self.reason,
+            "confidence": self.confidence
+        }
+
+
+@dataclass
+class RefinementDeltas:
+    """What the agents changed from raw CV output"""
+    
+    # Component changes
+    components_confirmed: int = 0
+    components_rejected: int = 0
+    components_added: int = 0
+    components_type_corrected: int = 0
+    components_bbox_adjusted: int = 0
+    
+    # Wire changes
+    wires_kept: int = 0
+    wires_rejected: int = 0
+    wires_merged: int = 0
+    wires_added: int = 0
+    
+    # Node changes
+    nodes_confirmed: int = 0
+    nodes_reclassified: int = 0
+    nodes_added: int = 0
+    nodes_merged: int = 0
+    
+    # Terminal changes
+    terminals_located: int = 0
+    terminals_connected: int = 0
+    
+    # Detailed change log
+    change_log: List[ChangeLogEntry] = field(default_factory=list)
+    
+    def add_change(self, agent: str, iteration: int, action: str,
+                   target_type: str, target_id: str, **kwargs):
+        """Add a change to the log"""
+        entry = ChangeLogEntry(
+            agent=agent,
+            iteration=iteration,
+            action=action,
+            target_type=target_type,
+            target_id=target_id,
+            **kwargs
+        )
+        self.change_log.append(entry)
+        
+        # Update counters
+        if target_type == "component":
+            if action == "confirm":
+                self.components_confirmed += 1
+            elif action == "remove":
+                self.components_rejected += 1
+            elif action == "add":
+                self.components_added += 1
+            elif action == "modify":
+                self.components_type_corrected += 1
+        elif target_type == "wire":
+            if action == "confirm":
+                self.wires_kept += 1
+            elif action == "remove":
+                self.wires_rejected += 1
+            elif action == "merge":
+                self.wires_merged += 1
+            elif action == "add":
+                self.wires_added += 1
+    
+    def to_dict(self) -> Dict:
+        return {
+            "components_confirmed": self.components_confirmed,
+            "components_rejected": self.components_rejected,
+            "components_added": self.components_added,
+            "components_type_corrected": self.components_type_corrected,
+            "components_bbox_adjusted": self.components_bbox_adjusted,
+            "wires_kept": self.wires_kept,
+            "wires_rejected": self.wires_rejected,
+            "wires_merged": self.wires_merged,
+            "wires_added": self.wires_added,
+            "nodes_confirmed": self.nodes_confirmed,
+            "nodes_reclassified": self.nodes_reclassified,
+            "nodes_added": self.nodes_added,
+            "nodes_merged": self.nodes_merged,
+            "terminals_located": self.terminals_located,
+            "terminals_connected": self.terminals_connected,
+            "change_log": [c.to_dict() for c in self.change_log]
+        }
+
+
+@dataclass
+class TrainingDataSample:
+    """Complete training sample for multi-head YOLOv11m"""
+    
+    # ============= SAMPLE IDENTITY =============
+    sample_id: str
+    image_path: str
+    image_hash: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    
+    # ============= IMAGE DATA =============
+    image_width: int = 0
+    image_height: int = 0
+    image_channels: int = 3
+    
+    # ============= QUALITY FLAGS =============
+    needs_review: bool = False
+    review_reasons: List[str] = field(default_factory=list)
+    pipeline_status: str = "pending"  # SUCCESS | PARTIAL | FAILED
+    quality_tier: str = "pending"     # VERIFIED | CONFIDENT | LOW_CONFIDENCE | FAILED
+    overall_confidence: float = 0.0
+    
+    # ============= DIFFICULTY SCORING =============
+    difficulty_scores: Optional[DifficultyScores] = None
+    
+    # ============= ANNOTATIONS =============
+    component_annotations: List[ComponentAnnotation] = field(default_factory=list)
+    wire_annotations: List[WireAnnotation] = field(default_factory=list)
+    node_annotations: List[NodeAnnotation] = field(default_factory=list)
+    terminal_annotations: List[TerminalAnnotation] = field(default_factory=list)
+    
+    # ============= REFINEMENT DELTAS =============
+    refinement_deltas: Optional[RefinementDeltas] = None
+    
+    # ============= RAW CV DATA =============
+    raw_yolo_detections: List[Dict] = field(default_factory=list)
+    raw_hough_lines: List[Tuple[Tuple[int, int], Tuple[int, int]]] = field(default_factory=list)
+    raw_junction_candidates: List[Tuple[int, int]] = field(default_factory=list)
+    
+    # ============= TOPOLOGY =============
+    topology: Optional[TopologyAnnotation] = None
+    
+    # ============= SPICE OUTPUT =============
+    spice_netlist: str = ""
+    simulation_successful: bool = False
+    
+    def export_yolo_annotations(self, class_map: Dict[str, int]) -> str:
+        """Export component annotations in YOLO format"""
+        lines = []
+        for ann in self.component_annotations:
+            lines.append(ann.to_yolo_line())
+        return "\n".join(lines)
+    
+    def export_coco_annotations(self, image_id: int, class_map: Dict[str, int]) -> Dict:
+        """Export in COCO format"""
+        annotations = []
+        for i, ann in enumerate(self.component_annotations):
+            # Convert normalized to pixels
+            x = (ann.x_center - ann.width / 2) * self.image_width
+            y = (ann.y_center - ann.height / 2) * self.image_height
+            w = ann.width * self.image_width
+            h = ann.height * self.image_height
+            
+            annotations.append({
+                "id": i,
+                "image_id": image_id,
+                "category_id": ann.class_id,
+                "bbox": [x, y, w, h],
+                "area": w * h,
+                "iscrowd": 0,
+                "attributes": {
+                    "orientation": ann.orientation,
+                    "value_present": ann.value_present,
+                    "source": ann.source
+                }
+            })
+        
+        return {
+            "image": {
+                "id": image_id,
+                "file_name": self.image_path,
+                "width": self.image_width,
+                "height": self.image_height
+            },
+            "annotations": annotations
+        }
+    
+    def to_dict(self) -> Dict:
+        return {
+            "sample_id": self.sample_id,
+            "image_path": self.image_path,
+            "image_hash": self.image_hash,
+            "timestamp": self.timestamp,
+            "image_width": self.image_width,
+            "image_height": self.image_height,
+            "image_channels": self.image_channels,
+            "needs_review": self.needs_review,
+            "review_reasons": self.review_reasons,
+            "pipeline_status": self.pipeline_status,
+            "quality_tier": self.quality_tier,
+            "overall_confidence": self.overall_confidence,
+            "difficulty_scores": self.difficulty_scores.to_dict() if self.difficulty_scores else None,
+            "component_annotations": [a.to_dict() for a in self.component_annotations],
+            "wire_annotations": [a.to_dict() for a in self.wire_annotations],
+            "node_annotations": [a.to_dict() for a in self.node_annotations],
+            "terminal_annotations": [a.to_dict() for a in self.terminal_annotations],
+            "refinement_deltas": self.refinement_deltas.to_dict() if self.refinement_deltas else None,
+            "raw_yolo_detections": self.raw_yolo_detections,
+            "raw_hough_lines": self.raw_hough_lines,
+            "raw_junction_candidates": self.raw_junction_candidates,
+            "topology": self.topology.to_dict() if self.topology else None,
+            "spice_netlist": self.spice_netlist,
+            "simulation_successful": self.simulation_successful
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'TrainingDataSample':
+        return cls(
+            sample_id=d["sample_id"],
+            image_path=d["image_path"],
+            image_hash=d.get("image_hash", ""),
+            timestamp=d.get("timestamp", ""),
+            image_width=d.get("image_width", 0),
+            image_height=d.get("image_height", 0),
+            image_channels=d.get("image_channels", 3),
+            needs_review=d.get("needs_review", False),
+            review_reasons=d.get("review_reasons", []),
+            pipeline_status=d.get("pipeline_status", "pending"),
+            quality_tier=d.get("quality_tier", "pending"),
+            overall_confidence=d.get("overall_confidence", 0.0),
+            difficulty_scores=DifficultyScores.from_dict(d["difficulty_scores"]) if d.get("difficulty_scores") else None,
+            component_annotations=[],  # Would need to implement from_dict for these
+            wire_annotations=[],
+            node_annotations=[],
+            terminal_annotations=[],
+            refinement_deltas=None,
+            raw_yolo_detections=d.get("raw_yolo_detections", []),
+            raw_hough_lines=d.get("raw_hough_lines", []),
+            raw_junction_candidates=d.get("raw_junction_candidates", []),
+            topology=TopologyAnnotation.from_dict(d["topology"]) if d.get("topology") else None,
+            spice_netlist=d.get("spice_netlist", ""),
+            simulation_successful=d.get("simulation_successful", False)
+        )
+

--- a/agents_v2/models/wires.py
+++ b/agents_v2/models/wires.py
@@ -1,0 +1,258 @@
+"""
+Wire-related data models with spatial information
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Tuple
+from .components import Point, LineSegment, BoundingBox
+
+
+@dataclass
+class SegmentAnnotation:
+    """Individual wire segment annotation for training"""
+    
+    # Line segment (x1, y1, x2, y2) in pixels
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    
+    # Properties
+    length: float = 0.0
+    angle: float = 0.0               # Degrees from horizontal
+    
+    # Classification
+    segment_type: str = "wire"       # "wire", "component_internal", "noise", "text"
+    confidence: float = 0.0
+    
+    # Source
+    hough_line_id: Optional[int] = None
+    
+    def __post_init__(self):
+        if self.length == 0.0:
+            import math
+            self.length = math.sqrt((self.x2 - self.x1)**2 + (self.y2 - self.y1)**2)
+        if self.angle == 0.0:
+            import math
+            self.angle = math.degrees(math.atan2(self.y2 - self.y1, self.x2 - self.x1))
+    
+    def to_line_segment(self) -> LineSegment:
+        return LineSegment(
+            start=Point(x=self.x1, y=self.y1),
+            end=Point(x=self.x2, y=self.y2)
+        )
+    
+    def to_normalized(self, img_width: int, img_height: int) -> Tuple[float, float, float, float]:
+        """Get normalized coordinates"""
+        return (
+            self.x1 / img_width,
+            self.y1 / img_height,
+            self.x2 / img_width,
+            self.y2 / img_height
+        )
+    
+    def to_dict(self) -> Dict:
+        return {
+            "x1": self.x1, "y1": self.y1,
+            "x2": self.x2, "y2": self.y2,
+            "length": self.length,
+            "angle": self.angle,
+            "segment_type": self.segment_type,
+            "confidence": self.confidence,
+            "hough_line_id": self.hough_line_id
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'SegmentAnnotation':
+        return cls(**d)
+
+
+@dataclass
+class JunctionInfo:
+    """Wire junction/intersection information"""
+    
+    id: str
+    position: Point
+    type: str = "junction"           # "junction", "crossing", "corner", "T_junction"
+    
+    # What meets here
+    connected_wires: List[str] = field(default_factory=list)
+    connected_terminals: List[str] = field(default_factory=list)
+    
+    # Visual info
+    has_junction_dot: bool = False   # Explicit dot in schematic
+    is_crossing_not_junction: bool = False  # Wires cross but don't connect
+    
+    # Electrical node
+    electrical_node: str = ""
+    
+    # Confidence
+    confidence: float = 0.0
+    source: str = "hough_intersection"  # or "agent_identified"
+    
+    @property
+    def connection_count(self) -> int:
+        return len(self.connected_wires) + len(self.connected_terminals)
+    
+    def to_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "position": self.position.to_dict(),
+            "type": self.type,
+            "connected_wires": self.connected_wires,
+            "connected_terminals": self.connected_terminals,
+            "has_junction_dot": self.has_junction_dot,
+            "is_crossing_not_junction": self.is_crossing_not_junction,
+            "electrical_node": self.electrical_node,
+            "confidence": self.confidence,
+            "source": self.source
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'JunctionInfo':
+        return cls(
+            id=d["id"],
+            position=Point.from_dict(d["position"]),
+            type=d.get("type", "junction"),
+            connected_wires=d.get("connected_wires", []),
+            connected_terminals=d.get("connected_terminals", []),
+            has_junction_dot=d.get("has_junction_dot", False),
+            is_crossing_not_junction=d.get("is_crossing_not_junction", False),
+            electrical_node=d.get("electrical_node", ""),
+            confidence=d.get("confidence", 0.0),
+            source=d.get("source", "hough_intersection")
+        )
+
+
+@dataclass
+class WireInfo:
+    """Wire segment information with path data"""
+    
+    id: str                          # "W1", "W2", etc.
+    
+    # Path (ordered list of points)
+    path: List[Point] = field(default_factory=list)
+    
+    # What it connects
+    start_connection: str = ""       # "R1.pin1" or "junction_3"
+    end_connection: str = ""
+    electrical_node: str = ""        # Which electrical node this wire is part of
+    
+    # Segments
+    segments: List[SegmentAnnotation] = field(default_factory=list)
+    
+    # Junctions along this wire
+    junctions: List[str] = field(default_factory=list)  # Junction IDs
+    
+    # Properties (computed)
+    total_length: float = 0.0
+    bend_count: int = 0
+    
+    # Source info
+    source: str = "hough_kept"       # "hough_kept", "hough_merged", "agent_traced"
+    source_hough_ids: List[int] = field(default_factory=list)
+    confidence: float = 0.0
+    
+    @property
+    def start_point(self) -> Optional[Point]:
+        return self.path[0] if self.path else None
+    
+    @property
+    def end_point(self) -> Optional[Point]:
+        return self.path[-1] if self.path else None
+    
+    @property
+    def is_horizontal(self) -> bool:
+        if len(self.path) < 2:
+            return False
+        return all(abs(self.path[i].y - self.path[i+1].y) < 5 
+                   for i in range(len(self.path)-1))
+    
+    @property
+    def is_vertical(self) -> bool:
+        if len(self.path) < 2:
+            return False
+        return all(abs(self.path[i].x - self.path[i+1].x) < 5 
+                   for i in range(len(self.path)-1))
+    
+    def compute_properties(self):
+        """Compute derived properties from path"""
+        if len(self.path) < 2:
+            return
+        
+        # Total length
+        self.total_length = sum(
+            self.path[i].distance_to(self.path[i+1])
+            for i in range(len(self.path) - 1)
+        )
+        
+        # Bend count (significant direction changes)
+        if len(self.path) >= 3:
+            import math
+            bends = 0
+            for i in range(1, len(self.path) - 1):
+                # Calculate angle change at this point
+                v1 = (self.path[i].x - self.path[i-1].x, 
+                      self.path[i].y - self.path[i-1].y)
+                v2 = (self.path[i+1].x - self.path[i].x,
+                      self.path[i+1].y - self.path[i].y)
+                
+                # Cross product for angle
+                cross = v1[0] * v2[1] - v1[1] * v2[0]
+                dot = v1[0] * v2[0] + v1[1] * v2[1]
+                angle = abs(math.degrees(math.atan2(cross, dot)))
+                
+                if angle > 20:  # More than 20 degrees = bend
+                    bends += 1
+            
+            self.bend_count = bends
+    
+    def get_bounding_box(self) -> Optional[BoundingBox]:
+        """Get bounding box of wire path"""
+        if not self.path:
+            return None
+        
+        x_coords = [p.x for p in self.path]
+        y_coords = [p.y for p in self.path]
+        
+        return BoundingBox(
+            x_min=min(x_coords),
+            y_min=min(y_coords),
+            x_max=max(x_coords),
+            y_max=max(y_coords)
+        )
+    
+    def to_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "path": [p.to_dict() for p in self.path],
+            "start_connection": self.start_connection,
+            "end_connection": self.end_connection,
+            "electrical_node": self.electrical_node,
+            "segments": [s.to_dict() for s in self.segments],
+            "junctions": self.junctions,
+            "total_length": self.total_length,
+            "bend_count": self.bend_count,
+            "source": self.source,
+            "source_hough_ids": self.source_hough_ids,
+            "confidence": self.confidence
+        }
+    
+    @classmethod
+    def from_dict(cls, d: Dict) -> 'WireInfo':
+        wire = cls(
+            id=d["id"],
+            path=[Point.from_dict(p) for p in d.get("path", [])],
+            start_connection=d.get("start_connection", ""),
+            end_connection=d.get("end_connection", ""),
+            electrical_node=d.get("electrical_node", ""),
+            segments=[SegmentAnnotation.from_dict(s) for s in d.get("segments", [])],
+            junctions=d.get("junctions", []),
+            total_length=d.get("total_length", 0.0),
+            bend_count=d.get("bend_count", 0),
+            source=d.get("source", "hough_kept"),
+            source_hough_ids=d.get("source_hough_ids", []),
+            confidence=d.get("confidence", 0.0)
+        )
+        return wire
+

--- a/agents_v2/run.py
+++ b/agents_v2/run.py
@@ -1,0 +1,901 @@
+#!/usr/bin/env python3
+"""
+Agents V2 Pipeline - CLI Entry Point with Parallel Processing
+
+Usage:
+    # Single image
+    python -m agents_v2.run --image sample-images/330.jpg
+    
+    # Batch processing (sequential)
+    python -m agents_v2.run --batch sample-images/ --output results/
+    
+    # Parallel batch processing (recommended for large batches)
+    python -m agents_v2.run --batch sample-images/ --parallel --workers 4
+    
+    # Full scale (6500 images)
+    python -m agents_v2.run --batch /path/to/images/ --parallel --workers 8 --batch-size 100
+"""
+
+import argparse
+import json
+import sys
+import os
+import shutil
+import traceback
+from pathlib import Path
+from typing import List, Dict, Optional, Tuple
+from dataclasses import dataclass, field
+from datetime import datetime
+import time
+import logging
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+import multiprocessing as mp
+
+# Add parent to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    datefmt='%H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OUTPUT STRUCTURE
+# ═══════════════════════════════════════════════════════════════════════════════
+# output_dir/
+# ├── images/           # Original images (copied)
+# │   ├── 330.jpg
+# │   └── ...
+# ├── spice/            # SPICE netlist files only
+# │   ├── 330.sp
+# │   └── ...
+# ├── captions/         # Circuit captions/descriptions
+# │   ├── 330.txt
+# │   └── ...
+# ├── detection/        # CV detection outputs per image
+# │   ├── 330/
+# │   │   ├── components_overlay.png
+# │   │   ├── lines_overlay.png
+# │   │   ├── detection_data.json
+# │   │   └── ...
+# │   └── ...
+# ├── agents/           # Agent outputs per image
+# │   ├── 330/
+# │   │   ├── 330_result.json
+# │   │   ├── 330_llm_flow.md
+# │   │   ├── 330_simulation.log
+# │   │   └── ...
+# │   └── ...
+# └── summary.json      # Batch summary
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class BatchStats:
+    """Statistics for batch processing"""
+    total: int = 0
+    processed: int = 0
+    success: int = 0
+    partial: int = 0
+    failed: int = 0
+    errors: int = 0
+    needs_review: int = 0
+    total_time: float = 0.0
+    avg_time_per_image: float = 0.0
+    total_tokens: int = 0
+    total_llm_calls: int = 0
+    
+    def to_dict(self) -> Dict:
+        return {
+            "total": self.total,
+            "processed": self.processed,
+            "success": self.success,
+            "partial": self.partial,
+            "failed": self.failed,
+            "errors": self.errors,
+            "needs_review": self.needs_review,
+            "total_time_seconds": round(self.total_time, 2),
+            "avg_time_per_image_seconds": round(self.avg_time_per_image, 2),
+            "total_tokens": self.total_tokens,
+            "total_llm_calls": self.total_llm_calls
+        }
+
+
+def setup_output_dirs(output_dir: Path) -> Dict[str, Path]:
+    """Create output directory structure"""
+    dirs = {
+        "root": output_dir,
+        "images": output_dir / "images",
+        "spice": output_dir / "spice",
+        "captions": output_dir / "captions",
+        "detection": output_dir / "detection",
+        "agents": output_dir / "agents"
+    }
+    
+    for d in dirs.values():
+        d.mkdir(parents=True, exist_ok=True)
+    
+    return dirs
+
+
+def load_cv_detections(
+    image_path: str, 
+    output_dirs: Dict[str, Path],
+    image_stem: str,
+    quiet: bool = False
+) -> Dict:
+    """
+    Load or run CV detections for an image using the actual detection pipeline.
+    Saves outputs to detection/{image_stem}/ directory.
+    """
+    import cv2
+    import numpy as np
+    
+    if not quiet:
+        print(f"  Running CV detection pipeline...")
+    
+    # Load image
+    img = cv2.imread(image_path)
+    if img is None:
+        raise FileNotFoundError(f"Could not load image: {image_path}")
+    
+    height, width = img.shape[:2]
+    
+    # Create per-image detection directory
+    detection_dir = output_dirs["detection"] / image_stem
+    detection_dir.mkdir(parents=True, exist_ok=True)
+    
+    try:
+        # Import the main detection pipeline
+        from main import main as run_component_detection
+        from PIL import Image
+        import matplotlib
+        matplotlib.use('Agg', force=True)
+        import matplotlib.pyplot as plt
+        
+        # Load image as numpy array
+        pil_img = Image.open(image_path)
+        inp = np.array(pil_img)
+        
+        # Save scanned_circuit.png for detection pipeline
+        scanned_path = detection_dir / 'scanned_circuit.png'
+        try:
+            # Use PIL to save directly instead of matplotlib for reliability
+            pil_img.save(str(scanned_path))
+        except Exception as e:
+            # Fallback to matplotlib
+            try:
+                plt.figure(figsize=(5, 5))
+                plt.imshow(pil_img)
+                plt.axis('off')
+                plt.savefig(str(scanned_path), bbox_inches='tight')
+                plt.close()
+            except Exception as e2:
+                if not quiet:
+                    print(f"    Warning: Could not save scanned_circuit.png: {e2}")
+                # Last resort: copy original
+                import shutil
+                shutil.copy2(image_path, scanned_path)
+        
+        # Run the full detection pipeline
+        rebuilt, comp, nodes, _, og_with_labels, comp_with_labels, comp_list, jns_list, conn_list, sample_dict = run_component_detection(
+            str(detection_dir), inp, image_stem, use_clustering=False
+        )
+        
+        # Get YOLO detections directly from the YOLO model
+        from utils.yolov8 import comp_detection
+        _, dim_matrix = comp_detection(str(scanned_path))
+        
+        # Classes from YOLO model (must match main.py exactly!)
+        yolo_classes = ['AC_Source', 'BJT', 'Battery', 'Capacitor', 'Current_Source', 'DC_Source', 'Diode', 'Ground', 'Inductor', 'MOSFET', 'Resistor', 'Voltage_Source']
+        
+        # Save detection overlays with error handling
+        try:
+            if comp_with_labels is not None and hasattr(comp_with_labels, 'shape'):
+                Image.fromarray(comp_with_labels).save(str(detection_dir / 'components_overlay.png'))
+        except Exception as e:
+            if not quiet:
+                print(f"    Warning: Could not save components_overlay: {e}")
+        
+        try:
+            if og_with_labels is not None and hasattr(og_with_labels, 'shape'):
+                Image.fromarray(og_with_labels).save(str(detection_dir / 'lines_overlay.png'))
+        except Exception as e:
+            if not quiet:
+                print(f"    Warning: Could not save lines_overlay: {e}")
+        
+        # Save optional visualizations with validation
+        def safe_save_plot(img_array, filepath, title=""):
+            """Safely save a plot from numpy array"""
+            try:
+                if img_array is None:
+                    return False
+                if not hasattr(img_array, 'shape'):
+                    return False
+                if len(img_array.shape) < 2:
+                    return False
+                # Ensure it's a valid image array
+                if img_array.dtype != np.uint8:
+                    if img_array.max() <= 1.0:
+                        img_array = (img_array * 255).astype(np.uint8)
+                    else:
+                        img_array = img_array.astype(np.uint8)
+                
+                plt.figure(figsize=(8, 8))
+                plt.imshow(img_array)
+                plt.axis('off')
+                if title:
+                    plt.title(title)
+                plt.savefig(str(filepath), bbox_inches='tight', dpi=150)
+                plt.close()
+                return True
+            except Exception as e:
+                if not quiet:
+                    print(f"    Warning: Could not save {filepath.name}: {e}")
+                plt.close('all')  # Clean up any open figures
+                return False
+        
+        safe_save_plot(comp, detection_dir / 'detected_components.png', 
+                      f"Detected Components ({len(comp_list)})")
+        safe_save_plot(nodes, detection_dir / 'nodes_terminals.png',
+                      f"Nodes & Terminals ({len(jns_list)})")
+        safe_save_plot(rebuilt, detection_dir / 'rebuilt_circuit.png',
+                      "Rebuilt Circuit")
+        
+        # Save text descriptions
+        with open(detection_dir / 'components.txt', 'w') as f:
+            f.write(f"# Components Detected: {len(comp_list)}\n\n")
+            for line in comp_list:
+                f.write(f"{line}\n")
+        
+        with open(detection_dir / 'nodes.txt', 'w') as f:
+            f.write(f"# Nodes Detected: {len(jns_list)}\n\n")
+            for line in jns_list:
+                f.write(f"{line}\n")
+        
+        with open(detection_dir / 'connections.txt', 'w') as f:
+            f.write(f"# Connections: {len(conn_list)}\n\n")
+            for line in conn_list:
+                f.write(f"{line}\n")
+        
+        if not quiet:
+            print(f"    Components: {len(comp_list)}, Nodes: {len(jns_list)}, Connections: {len(conn_list)}")
+        
+        # Parse YOLO detections directly from dim_matrix
+        yolo_detections = []
+        for i in range(dim_matrix.shape[0]):
+            dim = dim_matrix[i]
+            class_idx = int(dim[5])
+            class_name = yolo_classes[class_idx] if class_idx < len(yolo_classes) else "Unknown"
+            
+            yolo_detections.append({
+                "class": class_name,
+                "confidence": float(dim[4]) if len(dim) > 4 else 0.8,
+                "x_min": int(dim[0]),
+                "y_min": int(dim[1]),
+                "x_max": int(dim[2]),
+                "y_max": int(dim[3])
+            })
+        
+        # Parse Hough lines
+        hough_lines = []
+        if 'lines' in sample_dict:
+            for line in sample_dict.get('lines', []):
+                hough_lines.append({
+                    "start": {"x": int(line[0]), "y": int(line[1])},
+                    "end": {"x": int(line[2]), "y": int(line[3])}
+                })
+        else:
+            gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+            edges = cv2.Canny(gray, 50, 150)
+            lines = cv2.HoughLinesP(edges, 1, np.pi/180, 50, minLineLength=20, maxLineGap=10)
+            if lines is not None:
+                for line in lines:
+                    x1, y1, x2, y2 = line[0]
+                    hough_lines.append({
+                        "start": {"x": int(x1), "y": int(y1)},
+                        "end": {"x": int(x2), "y": int(y2)}
+                    })
+        
+        # Parse junction candidates
+        junctions = []
+        for jn_str in jns_list:
+            try:
+                import re
+                coords = re.findall(r'\((\d+),\s*(\d+)\)', jn_str)
+                if coords:
+                    for x, y in coords:
+                        junctions.append({"x": int(x), "y": int(y)})
+            except Exception:
+                pass
+        
+        if not junctions and 'junctions' in sample_dict:
+            for jn in sample_dict.get('junctions', []):
+                junctions.append({
+                    "x": int(jn.get('x', jn[0] if isinstance(jn, list) else 0)),
+                    "y": int(jn.get('y', jn[1] if isinstance(jn, list) else 0))
+                })
+        
+        result = {
+            "yolo_detections": yolo_detections,
+            "hough_lines": hough_lines,
+            "junction_candidates": junctions,
+            "image_size": {"width": width, "height": height},
+            "comp_list": comp_list,
+            "jns_list": jns_list,
+            "conn_list": conn_list,
+            "sample_dict": sample_dict
+        }
+        
+        # Save detection data as JSON
+        detection_data = {
+            "yolo_detections": yolo_detections,
+            "hough_lines": hough_lines,
+            "junction_candidates": junctions,
+            "image_size": {"width": width, "height": height},
+            "components": comp_list,
+            "nodes": jns_list,
+            "connections": conn_list
+        }
+        with open(detection_dir / 'detection_data.json', 'w') as f:
+            json.dump(detection_data, f, indent=2)
+        
+        return result
+        
+    except ImportError as e:
+        if not quiet:
+            print(f"  Warning: Main detection pipeline not available ({e})")
+            print(f"  Falling back to direct YOLO + Hough detection...")
+        
+        try:
+            from ultralytics import YOLO
+            
+            yolo_path = "trained_checkpoints/yolov8_best.pt"
+            if not Path(yolo_path).exists():
+                yolo_path = "runs/train/circuit_yolov11s_stable/weights/best.pt"
+            
+            yolo_model = YOLO(yolo_path)
+            yolo_results = yolo_model(image_path, conf=0.25)
+            
+            yolo_detections = []
+            for result in yolo_results:
+                for box in result.boxes:
+                    x1, y1, x2, y2 = box.xyxy[0].cpu().numpy()
+                    yolo_detections.append({
+                        "class": result.names[int(box.cls[0])],
+                        "confidence": float(box.conf[0]),
+                        "x_min": int(x1),
+                        "y_min": int(y1),
+                        "x_max": int(x2),
+                        "y_max": int(y2)
+                    })
+            
+            gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+            edges = cv2.Canny(gray, 50, 150)
+            lines = cv2.HoughLinesP(edges, 1, np.pi/180, 50, minLineLength=20, maxLineGap=10)
+            
+            hough_lines = []
+            if lines is not None:
+                for line in lines:
+                    x1, y1, x2, y2 = line[0]
+                    hough_lines.append({
+                        "start": {"x": int(x1), "y": int(y1)},
+                        "end": {"x": int(x2), "y": int(y2)}
+                    })
+            
+            from utils.node_detector import node_detector
+            junctions_raw = node_detector(gray)
+            junctions = [{"x": int(j[1]), "y": int(j[0])} for j in junctions_raw]
+            
+            return {
+                "yolo_detections": yolo_detections,
+                "hough_lines": hough_lines,
+                "junction_candidates": junctions,
+                "image_size": {"width": width, "height": height}
+            }
+            
+        except Exception as e2:
+            return {
+                "yolo_detections": [],
+                "hough_lines": [],
+                "junction_candidates": [],
+                "image_size": {"width": width, "height": height},
+                "error": str(e2)
+            }
+
+
+def process_single_image(
+    image_path: str,
+    output_dirs: Dict[str, Path],
+    config: 'PipelineConfig',
+    quiet: bool = False
+) -> Tuple[str, Dict, Optional[str]]:
+    """
+    Process a single image through the full pipeline.
+    Returns: (image_stem, output_dict, error_message)
+    """
+    from agents_v2.workflow import run_pipeline
+
+    # Validate image_path
+    if not isinstance(image_path, (str, Path)):
+        return ("invalid", {
+            "status": "ERROR",
+            "confidence": 0.0,
+            "needs_review": True,
+            "review_reasons": [f"Invalid image path type: {type(image_path)}"],
+            "tokens": 0,
+            "llm_calls": 0,
+            "time": 0.0
+        }, f"Invalid image path type: {type(image_path)}")
+
+    image_stem = Path(image_path).stem
+    start_time = time.time()
+
+    try:
+        # Copy original image to images/
+        dest_image = output_dirs["images"] / Path(image_path).name
+        if not dest_image.exists():
+            shutil.copy2(image_path, dest_image)
+        
+        # Run CV detection
+        detections = load_cv_detections(image_path, output_dirs, image_stem, quiet)
+        
+        # Create per-image agents directory
+        agents_dir = output_dirs["agents"] / image_stem
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Run agent pipeline
+        output = run_pipeline(
+            image_path=image_path,
+            yolo_detections=detections["yolo_detections"],
+            hough_lines=detections["hough_lines"],
+            junction_candidates=detections["junction_candidates"],
+            config=config,
+            output_subdir=str(agents_dir)
+        )
+        
+        # Copy .sp to spice/ directory
+        sp_file = agents_dir / f"{image_stem}.sp"
+        if sp_file.exists():
+            shutil.copy2(sp_file, output_dirs["spice"] / f"{image_stem}.sp")
+        
+        # Copy caption to captions/ directory
+        caption_file = agents_dir / f"{image_stem}_caption.txt"
+        if caption_file.exists():
+            shutil.copy2(caption_file, output_dirs["captions"] / f"{image_stem}.txt")
+        
+        elapsed = time.time() - start_time
+        
+        return (image_stem, {
+            "status": output.overall_status,
+            "confidence": output.overall_confidence,
+            "needs_review": output.needs_review,
+            "review_reasons": output.review_reasons[:3] if output.review_reasons else [],
+            "tokens": output.total_tokens,
+            "llm_calls": output.total_llm_calls,
+            "time": round(elapsed, 2)
+        }, None)
+        
+    except Exception as e:
+        elapsed = time.time() - start_time
+        error_msg = f"{type(e).__name__}: {str(e)}"
+        if not quiet:
+            print(f"  ERROR: {error_msg}")
+            traceback.print_exc()
+        
+        return (image_stem, {
+            "status": "ERROR",
+            "confidence": 0.0,
+            "needs_review": True,
+            "review_reasons": [error_msg],
+            "tokens": 0,
+            "llm_calls": 0,
+            "time": round(elapsed, 2)
+        }, error_msg)
+
+
+def worker_init():
+    """Initialize worker process"""
+    import warnings
+    warnings.filterwarnings('ignore')
+    
+    # Set matplotlib backend for subprocess
+    import matplotlib
+    matplotlib.use('Agg', force=True)
+
+
+def process_batch_parallel(
+    images: List[Path],
+    output_dirs: Dict[str, Path],
+    config: 'PipelineConfig',
+    num_workers: int = 4,
+    batch_size: int = 50,
+    quiet: bool = False
+) -> Tuple[List[Dict], BatchStats]:
+    """
+    Process images in parallel using ProcessPoolExecutor.
+    
+    For CV detection (CPU-bound): use ProcessPoolExecutor
+    For LLM calls (IO-bound): could use ThreadPoolExecutor
+    
+    Due to complexity of mixed workload, we use ThreadPoolExecutor
+    which works better with shared resources.
+    """
+    stats = BatchStats(total=len(images))
+    results = []
+    
+    # Process in batches to manage memory
+    num_batches = (len(images) + batch_size - 1) // batch_size
+    
+    print(f"\n{'='*70}")
+    print(f"  PARALLEL BATCH PROCESSING")
+    print(f"  Total images: {len(images)}")
+    print(f"  Workers: {num_workers}")
+    print(f"  Batch size: {batch_size}")
+    print(f"  Total batches: {num_batches}")
+    print(f"{'='*70}")
+    
+    start_time = time.time()
+    
+    for batch_idx in range(num_batches):
+        batch_start = batch_idx * batch_size
+        batch_end = min(batch_start + batch_size, len(images))
+        batch_images = images[batch_start:batch_end]
+        
+        print(f"\n  Batch {batch_idx + 1}/{num_batches} ({len(batch_images)} images)")
+        print(f"  {'-'*60}")
+        
+        batch_start_time = time.time()
+        
+        # Use ThreadPoolExecutor for mixed IO/CPU workload
+        with ThreadPoolExecutor(max_workers=num_workers) as executor:
+            futures = {
+                executor.submit(
+                    process_single_image,
+                    str(img_path),
+                    output_dirs,
+                    config,
+                    quiet=True  # Quiet in parallel mode
+                ): img_path
+                for img_path in batch_images
+            }
+            
+            for future in as_completed(futures):
+                img_path = futures[future]
+                try:
+                    image_stem, result, error = future.result()
+                    results.append({"image": image_stem, **result})
+                    
+                    stats.processed += 1
+                    stats.total_tokens += result.get("tokens", 0)
+                    stats.total_llm_calls += result.get("llm_calls", 0)
+                    
+                    if error:
+                        stats.errors += 1
+                        # Show more of the error message for debugging
+                        error_display = error if len(error) <= 100 else f"{error[:100]}..."
+                        print(f"    ✗ {image_stem}: ERROR - {error_display}")
+                    elif result["status"] == "SUCCESS":
+                        stats.success += 1
+                        print(f"    ✓ {image_stem}: SUCCESS ({result['confidence']:.2f})")
+                    elif result["status"] == "PARTIAL":
+                        stats.partial += 1
+                        print(f"    ⚠ {image_stem}: PARTIAL ({result['confidence']:.2f})")
+                    else:
+                        stats.failed += 1
+                        print(f"    ✗ {image_stem}: FAILED")
+                    
+                    if result.get("needs_review"):
+                        stats.needs_review += 1
+                        
+                except Exception as e:
+                    stats.errors += 1
+                    img_name = img_path.stem if hasattr(img_path, 'stem') else str(img_path)
+                    print(f"    ✗ {img_name}: EXCEPTION - {e}")
+        
+        batch_time = time.time() - batch_start_time
+        print(f"  Batch completed in {batch_time:.1f}s ({batch_time/len(batch_images):.1f}s/image)")
+    
+    stats.total_time = time.time() - start_time
+    stats.avg_time_per_image = stats.total_time / max(stats.processed, 1)
+    
+    return results, stats
+
+
+def process_batch_sequential(
+    images: List[Path],
+    output_dirs: Dict[str, Path],
+    config: 'PipelineConfig',
+    quiet: bool = False
+) -> Tuple[List[Dict], BatchStats]:
+    """Process images sequentially (for debugging or small batches)"""
+    stats = BatchStats(total=len(images))
+    results = []
+    
+    print(f"\n{'='*70}")
+    print(f"  SEQUENTIAL BATCH PROCESSING")
+    print(f"  Total images: {len(images)}")
+    print(f"{'='*70}")
+    
+    start_time = time.time()
+    
+    for i, img_path in enumerate(images):
+        print(f"\n[{i+1}/{len(images)}] {img_path.name}")
+        
+        image_stem, result, error = process_single_image(
+            str(img_path),
+            output_dirs,
+            config,
+            quiet
+        )
+        
+        results.append({"image": image_stem, **result})
+        
+        stats.processed += 1
+        stats.total_tokens += result.get("tokens", 0)
+        stats.total_llm_calls += result.get("llm_calls", 0)
+        
+        if error:
+            stats.errors += 1
+        elif result["status"] == "SUCCESS":
+            stats.success += 1
+        elif result["status"] == "PARTIAL":
+            stats.partial += 1
+        else:
+            stats.failed += 1
+        
+        if result.get("needs_review"):
+            stats.needs_review += 1
+        
+        print(f"  Result: {result['status']} (conf: {result['confidence']:.2f}, time: {result['time']:.1f}s)")
+    
+    stats.total_time = time.time() - start_time
+    stats.avg_time_per_image = stats.total_time / max(stats.processed, 1)
+    
+    return results, stats
+
+
+def run_single_image(
+    image_path: str,
+    config: 'PipelineConfig',
+    output_dir: str = "agents_v2_output"
+) -> Dict:
+    """Run pipeline on a single image"""
+    
+    print(f"\n{'='*70}")
+    print(f"  Processing: {image_path}")
+    print(f"{'='*70}")
+    
+    # Setup output directories
+    output_dirs = setup_output_dirs(Path(output_dir))
+    
+    # Process image
+    image_stem, result, error = process_single_image(
+        image_path,
+        output_dirs,
+        config,
+        quiet=False
+    )
+    
+    if error:
+        print(f"\n  ERROR: {error}")
+    else:
+        print(f"\n  Result: {result['status']}")
+        print(f"  Confidence: {result['confidence']:.3f}")
+        if result.get('needs_review'):
+            print(f"  ⚠ NEEDS REVIEW: {result['review_reasons']}")
+    
+    # Create a minimal output object for compatibility
+    from types import SimpleNamespace
+    output = SimpleNamespace(
+        overall_status=result['status'],
+        overall_confidence=result['confidence'],
+        needs_review=result.get('needs_review', False),
+        review_reasons=result.get('review_reasons', []),
+        total_tokens=result.get('tokens', 0),
+        total_llm_calls=result.get('llm_calls', 0)
+    )
+    
+    return output
+
+
+def run_batch(
+    image_dir: str,
+    config: 'PipelineConfig',
+    output_dir: str,
+    parallel: bool = False,
+    num_workers: int = 4,
+    batch_size: int = 50,
+    export_training: bool = False
+) -> Tuple[List[Dict], BatchStats]:
+    """Run pipeline on batch of images"""
+    
+    image_dir = Path(image_dir)
+    output_dirs = setup_output_dirs(Path(output_dir))
+    
+    # Find images
+    image_extensions = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff'}
+    images = sorted([
+        f for f in image_dir.iterdir()
+        if f.is_file() and f.suffix.lower() in image_extensions
+    ])
+    
+    if not images:
+        print(f"No images found in {image_dir}")
+        return [], BatchStats()
+    
+    # Process
+    if parallel:
+        results, stats = process_batch_parallel(
+            images, output_dirs, config, num_workers, batch_size
+        )
+    else:
+        results, stats = process_batch_sequential(
+            images, output_dirs, config
+        )
+    
+    # Save summary
+    summary = {
+        "timestamp": datetime.now().isoformat(),
+        "input_dir": str(image_dir),
+        "output_dir": str(output_dir),
+        "parallel": parallel,
+        "workers": num_workers if parallel else 1,
+        "batch_size": batch_size if parallel else 1,
+        "stats": stats.to_dict(),
+        "results": results
+    }
+    
+    summary_path = output_dirs["root"] / "summary.json"
+    with open(summary_path, 'w') as f:
+        json.dump(summary, f, indent=2)
+    
+    # Print summary
+    print(f"\n{'='*70}")
+    print(f"  BATCH SUMMARY")
+    print(f"{'='*70}")
+    print(f"  Total:        {stats.total}")
+    print(f"  Processed:    {stats.processed}")
+    print(f"  Success:      {stats.success} ({100*stats.success/max(stats.processed,1):.1f}%)")
+    print(f"  Partial:      {stats.partial} ({100*stats.partial/max(stats.processed,1):.1f}%)")
+    print(f"  Failed:       {stats.failed} ({100*stats.failed/max(stats.processed,1):.1f}%)")
+    print(f"  Errors:       {stats.errors}")
+    print(f"  Needs Review: {stats.needs_review}")
+    print(f"  {'-'*60}")
+    print(f"  Total Time:   {stats.total_time:.1f}s ({stats.total_time/60:.1f}m)")
+    print(f"  Avg/Image:    {stats.avg_time_per_image:.1f}s")
+    print(f"  LLM Calls:    {stats.total_llm_calls}")
+    print(f"  Total Tokens: {stats.total_tokens}")
+    print(f"  {'-'*60}")
+    print(f"  Summary saved: {summary_path}")
+    print(f"{'='*70}")
+    
+    return results, stats
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Agents V2 Refinement Pipeline with Parallel Processing",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Single image
+  python -m agents_v2.run --image sample-images/330.jpg
+  
+  # Sequential batch
+  python -m agents_v2.run --batch sample-images/ --output results/
+  
+  # Parallel batch (recommended for large datasets)
+  python -m agents_v2.run --batch sample-images/ --parallel --workers 4
+  
+  # Large scale (6500 images)
+  python -m agents_v2.run --batch /path/to/images/ --parallel --workers 8 --batch-size 100
+  
+  # With custom models
+  python -m agents_v2.run --batch images/ --parallel --agent-model gpt-4o
+        """
+    )
+    
+    # Input options
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--image", "-i", help="Single image to process")
+    input_group.add_argument("--batch", "-b", help="Directory of images to process")
+    
+    # Output options
+    parser.add_argument("--output", "-o", default="agents_v2_output",
+                       help="Output directory (default: agents_v2_output)")
+    parser.add_argument("--export-training", action="store_true",
+                       help="Export training data for curriculum learning")
+    
+    # Parallel processing options
+    parser.add_argument("--parallel", "-p", action="store_true",
+                       help="Enable parallel processing")
+    parser.add_argument("--workers", "-w", type=int, default=4,
+                       help="Number of parallel workers (default: 4)")
+    parser.add_argument("--batch-size", type=int, default=50,
+                       help="Images per batch for memory management (default: 50)")
+    
+    # Model options
+    parser.add_argument("--agent-model", default="gpt-5.2",
+                       help="Model for agents 1-3 (default: gpt-5.2)")
+    parser.add_argument("--judge-model", default="gpt-5.2",
+                       help="Model for LLM-as-Judge (default: gpt-5.2)")
+    parser.add_argument("--use-gpt4", action="store_true",
+                       help="Use GPT-4o models instead of GPT-5.2")
+    
+    # Pipeline options
+    parser.add_argument("--max-iterations", type=int, default=3,
+                       help="Max iterations per agent (default: 3)")
+    parser.add_argument("--pass-threshold", type=float, default=0.90,
+                       help="Score threshold to pass (default: 0.90)")
+    
+    # Other options
+    parser.add_argument("--quiet", "-q", action="store_true",
+                       help="Reduce output verbosity")
+    
+    args = parser.parse_args()
+    
+    # Import config here to avoid circular imports
+    from agents_v2.config import PipelineConfig, ModelConfig
+    
+    # Build config
+    if args.use_gpt4:
+        model_config = ModelConfig(
+            agent1_model="gpt-4o",
+            agent2_model="gpt-4o",
+            agent3_model="gpt-4o",
+            judge_model="gpt-4o",
+            use_gpt5=False
+        )
+    else:
+        model_config = ModelConfig(
+            agent1_model=args.agent_model,
+            agent2_model=args.agent_model,
+            agent3_model=args.agent_model,
+            judge_model=args.judge_model,
+            use_gpt5=True
+        )
+    
+    config = PipelineConfig(
+        models=model_config,
+        output_dir=args.output,
+        verbose=not args.quiet
+    )
+    
+    # Update thresholds if specified
+    if args.pass_threshold:
+        config.thresholds.agent1_pass_threshold = args.pass_threshold
+        config.thresholds.agent2_pass_threshold = args.pass_threshold
+        config.thresholds.agent3_pass_threshold = args.pass_threshold
+    
+    if args.max_iterations:
+        config.iterations.agent1_max_iterations = args.max_iterations
+        config.iterations.agent2_max_iterations = args.max_iterations
+        config.iterations.agent3_max_iterations = args.max_iterations
+    
+    # Run
+    start_time = time.time()
+    
+    if args.image:
+        output = run_single_image(args.image, config, args.output)
+    else:
+        results, stats = run_batch(
+            args.batch,
+            config,
+            args.output,
+            parallel=args.parallel,
+            num_workers=args.workers,
+            batch_size=args.batch_size,
+            export_training=args.export_training
+        )
+    
+    total_time = time.time() - start_time
+    print(f"\nTotal time: {total_time:.1f}s ({total_time/60:.1f}m)")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents_v2/training/__init__.py
+++ b/agents_v2/training/__init__.py
@@ -1,0 +1,13 @@
+"""
+Training utilities for curriculum learning with YOLOv11m
+"""
+
+from .data_exporter import TrainingDataExporter
+from .curriculum import CurriculumSampler, DifficultyTracker
+
+__all__ = [
+    "TrainingDataExporter",
+    "CurriculumSampler",
+    "DifficultyTracker"
+]
+

--- a/agents_v2/training/curriculum.py
+++ b/agents_v2/training/curriculum.py
@@ -1,0 +1,367 @@
+"""
+Curriculum Learning Utilities
+
+Implements EMA-based curriculum learning for training YOLOv11m
+with noisy synthetic data.
+"""
+
+import json
+import random
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+import math
+
+
+@dataclass
+class SampleDifficulty:
+    """Difficulty tracking for a single sample"""
+    sample_id: str
+    image_path: str
+    
+    # Static difficulty (computed once)
+    initial_difficulty: float = 0.5
+    curriculum_stage: int = 3
+    
+    # Dynamic difficulty (updated with EMA during training)
+    ema_loss: float = 0.0
+    ema_loss_component: float = 0.0
+    ema_loss_wire: float = 0.0
+    ema_loss_node: float = 0.0
+    
+    # Training history
+    times_sampled: int = 0
+    last_epoch_sampled: int = -1
+    avg_loss_history: List[float] = field(default_factory=list)
+    
+    # Flags
+    needs_review: bool = False
+    excluded: bool = False
+    
+    def update_ema(self, loss: float, component_loss: float = 0.0,
+                   wire_loss: float = 0.0, node_loss: float = 0.0,
+                   decay: float = 0.9):
+        """Update EMA losses after training on this sample"""
+        if self.times_sampled == 0:
+            # First sample - initialize
+            self.ema_loss = loss
+            self.ema_loss_component = component_loss
+            self.ema_loss_wire = wire_loss
+            self.ema_loss_node = node_loss
+        else:
+            # EMA update
+            self.ema_loss = decay * self.ema_loss + (1 - decay) * loss
+            self.ema_loss_component = decay * self.ema_loss_component + (1 - decay) * component_loss
+            self.ema_loss_wire = decay * self.ema_loss_wire + (1 - decay) * wire_loss
+            self.ema_loss_node = decay * self.ema_loss_node + (1 - decay) * node_loss
+        
+        self.times_sampled += 1
+        self.avg_loss_history.append(loss)
+    
+    @property
+    def dynamic_difficulty(self) -> float:
+        """Compute dynamic difficulty based on EMA loss"""
+        if self.times_sampled == 0:
+            return self.initial_difficulty
+        
+        # Combine static and dynamic difficulty
+        # High EMA loss = harder sample
+        # Normalize EMA loss to 0-1 range using sigmoid
+        normalized_loss = 1.0 / (1.0 + math.exp(-self.ema_loss + 1))
+        
+        # Blend with initial difficulty
+        return 0.3 * self.initial_difficulty + 0.7 * normalized_loss
+
+
+class DifficultyTracker:
+    """
+    Tracks sample difficulties and updates EMA during training.
+    """
+    
+    def __init__(self, manifest_path: Optional[str] = None, ema_decay: float = 0.9):
+        self.samples: Dict[str, SampleDifficulty] = {}
+        self.ema_decay = ema_decay
+        self.current_epoch = 0
+        
+        if manifest_path:
+            self.load_manifest(manifest_path)
+    
+    def load_manifest(self, manifest_path: str):
+        """Load difficulty manifest from JSON file"""
+        with open(manifest_path, 'r') as f:
+            manifest = json.load(f)
+        
+        for sample_data in manifest.get("samples", []):
+            sample = SampleDifficulty(
+                sample_id=sample_data["sample_id"],
+                image_path=sample_data["image_path"],
+                initial_difficulty=sample_data.get("overall_difficulty", 0.5),
+                curriculum_stage=sample_data.get("curriculum_stage", 3),
+                ema_loss_component=sample_data.get("ema_loss_component") or 0.0,
+                ema_loss_wire=sample_data.get("ema_loss_wire") or 0.0,
+                ema_loss_node=sample_data.get("ema_loss_node") or 0.0,
+                needs_review=sample_data.get("needs_review", False)
+            )
+            self.samples[sample.sample_id] = sample
+    
+    def save_manifest(self, output_path: str):
+        """Save updated difficulty manifest"""
+        manifest = {
+            "version": "1.0",
+            "current_epoch": self.current_epoch,
+            "ema_decay": self.ema_decay,
+            "samples": []
+        }
+        
+        for sample in self.samples.values():
+            manifest["samples"].append({
+                "sample_id": sample.sample_id,
+                "image_path": sample.image_path,
+                "initial_difficulty": sample.initial_difficulty,
+                "curriculum_stage": sample.curriculum_stage,
+                "dynamic_difficulty": sample.dynamic_difficulty,
+                "ema_loss": sample.ema_loss,
+                "ema_loss_component": sample.ema_loss_component,
+                "ema_loss_wire": sample.ema_loss_wire,
+                "ema_loss_node": sample.ema_loss_node,
+                "times_sampled": sample.times_sampled,
+                "needs_review": sample.needs_review,
+                "excluded": sample.excluded
+            })
+        
+        with open(output_path, 'w') as f:
+            json.dump(manifest, f, indent=2)
+    
+    def update_sample(self, sample_id: str, loss: float,
+                      component_loss: float = 0.0,
+                      wire_loss: float = 0.0,
+                      node_loss: float = 0.0):
+        """Update difficulty for a sample after training"""
+        if sample_id in self.samples:
+            sample = self.samples[sample_id]
+            sample.update_ema(loss, component_loss, wire_loss, node_loss, self.ema_decay)
+            sample.last_epoch_sampled = self.current_epoch
+    
+    def get_samples_for_stage(self, stage: int) -> List[str]:
+        """Get sample IDs for a curriculum stage"""
+        return [
+            s.sample_id for s in self.samples.values()
+            if s.curriculum_stage == stage and not s.excluded
+        ]
+    
+    def get_samples_up_to_stage(self, max_stage: int) -> List[str]:
+        """Get sample IDs for stages 1 through max_stage"""
+        return [
+            s.sample_id for s in self.samples.values()
+            if s.curriculum_stage <= max_stage and not s.excluded
+        ]
+    
+    def advance_epoch(self):
+        """Advance to next epoch"""
+        self.current_epoch += 1
+
+
+class CurriculumSampler:
+    """
+    Curriculum learning sampler for PyTorch DataLoader.
+    
+    Strategies:
+    1. Stage-based: Train on easy samples first, gradually include harder ones
+    2. Self-paced: Use EMA loss to dynamically adjust sample weights
+    3. Anti-curriculum: Train on hard samples first (for fine-tuning)
+    """
+    
+    def __init__(
+        self,
+        tracker: DifficultyTracker,
+        strategy: str = "stage_based",
+        stage_schedule: Optional[Dict[int, int]] = None
+    ):
+        """
+        Args:
+            tracker: DifficultyTracker with sample difficulties
+            strategy: "stage_based", "self_paced", or "anti_curriculum"
+            stage_schedule: Dict mapping stage -> epoch when to include
+                           e.g., {1: 0, 2: 5, 3: 10, 4: 15, 5: 20}
+        """
+        self.tracker = tracker
+        self.strategy = strategy
+        self.stage_schedule = stage_schedule or {
+            1: 0,   # Include stage 1 from epoch 0
+            2: 5,   # Include stage 2 from epoch 5
+            3: 10,  # Include stage 3 from epoch 10
+            4: 15,  # Include stage 4 from epoch 15
+            5: 20   # Include stage 5 from epoch 20
+        }
+    
+    def get_sample_ids(self, epoch: int) -> List[str]:
+        """Get list of sample IDs to train on for this epoch"""
+        
+        if self.strategy == "stage_based":
+            return self._stage_based_sampling(epoch)
+        elif self.strategy == "self_paced":
+            return self._self_paced_sampling(epoch)
+        elif self.strategy == "anti_curriculum":
+            return self._anti_curriculum_sampling(epoch)
+        else:
+            # All samples
+            return list(self.tracker.samples.keys())
+    
+    def get_sample_weights(self, epoch: int) -> Dict[str, float]:
+        """Get sampling weights for each sample"""
+        
+        weights = {}
+        sample_ids = self.get_sample_ids(epoch)
+        
+        if self.strategy == "self_paced":
+            # Weight by inverse of EMA loss (focus on learnable samples)
+            for sid in sample_ids:
+                sample = self.tracker.samples[sid]
+                # Avoid division by zero
+                weights[sid] = 1.0 / (sample.ema_loss + 0.1) if sample.times_sampled > 0 else 1.0
+        else:
+            # Equal weights
+            for sid in sample_ids:
+                weights[sid] = 1.0
+        
+        # Normalize weights
+        total = sum(weights.values())
+        if total > 0:
+            weights = {k: v / total for k, v in weights.items()}
+        
+        return weights
+    
+    def _stage_based_sampling(self, epoch: int) -> List[str]:
+        """Include samples based on curriculum stage schedule"""
+        
+        # Determine max stage for this epoch
+        max_stage = 1
+        for stage, start_epoch in sorted(self.stage_schedule.items()):
+            if epoch >= start_epoch:
+                max_stage = stage
+        
+        return self.tracker.get_samples_up_to_stage(max_stage)
+    
+    def _self_paced_sampling(self, epoch: int) -> List[str]:
+        """Dynamic sampling based on EMA loss"""
+        
+        # Start with stage-based, but adjust based on loss
+        base_samples = self._stage_based_sampling(epoch)
+        
+        if epoch < 5:
+            # Early epochs: stick to easy samples
+            return base_samples
+        
+        # After warmup: include samples where we're making progress
+        # (decreasing loss) even if they're harder
+        
+        all_samples = list(self.tracker.samples.values())
+        selected = set(base_samples)
+        
+        for sample in all_samples:
+            if sample.sample_id in selected:
+                continue
+            
+            # Check if loss is decreasing (learning happening)
+            if len(sample.avg_loss_history) >= 2:
+                recent_avg = sum(sample.avg_loss_history[-3:]) / min(3, len(sample.avg_loss_history))
+                older_avg = sum(sample.avg_loss_history[:-3]) / max(1, len(sample.avg_loss_history) - 3)
+                
+                if recent_avg < older_avg * 0.9:  # Loss decreased by >10%
+                    selected.add(sample.sample_id)
+        
+        return list(selected)
+    
+    def _anti_curriculum_sampling(self, epoch: int) -> List[str]:
+        """Start with hard samples (for fine-tuning pretrained models)"""
+        
+        # Reverse the stage schedule
+        max_stage = 5
+        for stage in sorted(self.stage_schedule.keys(), reverse=True):
+            if epoch >= self.stage_schedule[max_stage]:
+                break
+            max_stage = stage
+        
+        # Get samples from this stage and above
+        return [
+            s.sample_id for s in self.tracker.samples.values()
+            if s.curriculum_stage >= max_stage and not s.excluded
+        ]
+
+
+def create_pytorch_sampler(
+    tracker: DifficultyTracker,
+    epoch: int,
+    strategy: str = "stage_based",
+    **kwargs
+):
+    """
+    Create a PyTorch-compatible sampler for curriculum learning.
+    
+    Usage:
+        tracker = DifficultyTracker("difficulty_manifest.json")
+        sampler = create_pytorch_sampler(tracker, epoch=10)
+        dataloader = DataLoader(dataset, sampler=sampler, ...)
+    """
+    try:
+        from torch.utils.data import WeightedRandomSampler
+    except ImportError:
+        raise ImportError("PyTorch is required for this function")
+    
+    curriculum = CurriculumSampler(tracker, strategy, **kwargs)
+    
+    sample_ids = curriculum.get_sample_ids(epoch)
+    weights = curriculum.get_sample_weights(epoch)
+    
+    # Map to indices (assuming dataset is ordered by sample_id)
+    sample_to_idx = {sid: i for i, sid in enumerate(tracker.samples.keys())}
+    
+    indices = [sample_to_idx[sid] for sid in sample_ids]
+    sample_weights = [weights.get(sid, 0.0) for sid in sample_ids]
+    
+    return WeightedRandomSampler(
+        weights=sample_weights,
+        num_samples=len(indices),
+        replacement=True
+    )
+
+
+# Example training loop integration
+"""
+# In your training script:
+
+from agents_v2.training import DifficultyTracker, CurriculumSampler
+
+# Initialize
+tracker = DifficultyTracker("training_data/difficulty_manifest.json")
+curriculum = CurriculumSampler(tracker, strategy="stage_based")
+
+for epoch in range(num_epochs):
+    # Get samples for this epoch
+    sample_ids = curriculum.get_sample_ids(epoch)
+    
+    # Create subset dataset
+    epoch_dataset = Subset(full_dataset, 
+                          [dataset.sample_to_idx[sid] for sid in sample_ids])
+    
+    # Train
+    for batch in DataLoader(epoch_dataset, ...):
+        loss, component_loss, wire_loss, node_loss = train_step(batch)
+        
+        # Update difficulty tracking
+        for sample_id in batch.sample_ids:
+            tracker.update_sample(
+                sample_id, 
+                loss=loss.item(),
+                component_loss=component_loss.item(),
+                wire_loss=wire_loss.item(),
+                node_loss=node_loss.item()
+            )
+    
+    tracker.advance_epoch()
+    
+    # Save updated manifest periodically
+    if epoch % 5 == 0:
+        tracker.save_manifest("training_data/difficulty_manifest.json")
+"""
+

--- a/agents_v2/training/data_exporter.py
+++ b/agents_v2/training/data_exporter.py
@@ -1,0 +1,478 @@
+"""
+Training Data Exporter
+
+Exports agent-refined data to formats suitable for training:
+- YOLO format for object detection
+- COCO format for multi-task learning
+- Custom format with difficulty scores for curriculum learning
+"""
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+
+from ..models.training_data import TrainingDataSample, ComponentAnnotation
+from ..config import ExportConfig
+
+
+@dataclass
+class ExportStats:
+    """Statistics from export operation"""
+    total_samples: int = 0
+    exported_samples: int = 0
+    skipped_samples: int = 0
+    total_components: int = 0
+    total_wires: int = 0
+    total_nodes: int = 0
+    samples_by_stage: Dict[int, int] = None
+    samples_needing_review: int = 0
+    
+    def __post_init__(self):
+        if self.samples_by_stage is None:
+            self.samples_by_stage = {}
+
+
+class TrainingDataExporter:
+    """
+    Exports training data in multiple formats for multi-head YOLO training.
+    """
+    
+    def __init__(self, export_config: Optional[ExportConfig] = None):
+        self.config = export_config or ExportConfig()
+    
+    def export_yolo(
+        self,
+        samples: List[TrainingDataSample],
+        output_dir: str,
+        split_ratio: Tuple[float, float, float] = (0.8, 0.1, 0.1),
+        min_quality: str = "LOW_CONFIDENCE",
+        copy_images: bool = True
+    ) -> ExportStats:
+        """
+        Export samples to YOLO format.
+        
+        Args:
+            samples: List of training samples
+            output_dir: Output directory for YOLO dataset
+            split_ratio: (train, val, test) split ratios
+            min_quality: Minimum quality tier to include
+            copy_images: Whether to copy images to output directory
+        
+        Returns:
+            ExportStats with export statistics
+        """
+        
+        output_path = Path(output_dir)
+        stats = ExportStats()
+        
+        # Quality tier ordering
+        quality_order = ["FAILED", "LOW_CONFIDENCE", "CONFIDENT", "VERIFIED"]
+        min_quality_idx = quality_order.index(min_quality)
+        
+        # Filter samples by quality
+        valid_samples = []
+        for sample in samples:
+            sample_quality_idx = quality_order.index(sample.quality_tier) if sample.quality_tier in quality_order else 0
+            if sample_quality_idx >= min_quality_idx:
+                valid_samples.append(sample)
+                stats.total_components += len(sample.component_annotations)
+                stats.total_wires += len(sample.wire_annotations)
+                stats.total_nodes += len(sample.node_annotations)
+                
+                # Track by curriculum stage
+                if sample.difficulty_scores:
+                    stage = sample.difficulty_scores.curriculum_stage
+                    stats.samples_by_stage[stage] = stats.samples_by_stage.get(stage, 0) + 1
+                
+                if sample.needs_review:
+                    stats.samples_needing_review += 1
+            else:
+                stats.skipped_samples += 1
+        
+        stats.total_samples = len(samples)
+        stats.exported_samples = len(valid_samples)
+        
+        # Split samples
+        import random
+        random.shuffle(valid_samples)
+        
+        n = len(valid_samples)
+        train_end = int(n * split_ratio[0])
+        val_end = train_end + int(n * split_ratio[1])
+        
+        splits = {
+            "train": valid_samples[:train_end],
+            "val": valid_samples[train_end:val_end],
+            "test": valid_samples[val_end:]
+        }
+        
+        # Create directory structure
+        for split in ["train", "val", "test"]:
+            (output_path / split / "images").mkdir(parents=True, exist_ok=True)
+            (output_path / split / "labels").mkdir(parents=True, exist_ok=True)
+        
+        # Export samples
+        for split, split_samples in splits.items():
+            for sample in split_samples:
+                self._export_yolo_sample(
+                    sample, 
+                    output_path / split,
+                    copy_images
+                )
+        
+        # Create dataset.yaml
+        self._create_yolo_yaml(output_path)
+        
+        # Create difficulty manifest for curriculum learning
+        self._create_difficulty_manifest(valid_samples, output_path)
+        
+        return stats
+    
+    def _export_yolo_sample(
+        self,
+        sample: TrainingDataSample,
+        split_path: Path,
+        copy_images: bool
+    ):
+        """Export a single sample to YOLO format"""
+        
+        image_name = Path(sample.image_path).stem
+        
+        # Copy/link image
+        if copy_images:
+            src_image = Path(sample.image_path)
+            if src_image.exists():
+                dst_image = split_path / "images" / f"{image_name}.jpg"
+                shutil.copy2(src_image, dst_image)
+        
+        # Create label file
+        label_path = split_path / "labels" / f"{image_name}.txt"
+        
+        lines = []
+        for ann in sample.component_annotations:
+            lines.append(ann.to_yolo_line())
+        
+        with open(label_path, 'w') as f:
+            f.write("\n".join(lines))
+    
+    def _create_yolo_yaml(self, output_path: Path):
+        """Create YOLO dataset configuration file"""
+        
+        yaml_content = f"""# YOLOv11m Multi-Head Training Dataset
+# Generated by Agents V2 Pipeline
+
+path: {output_path.absolute()}
+train: train/images
+val: val/images
+test: test/images
+
+# Component Detection Head Classes
+names:
+"""
+        for name, idx in sorted(self.config.component_classes.items(), key=lambda x: x[1]):
+            yaml_content += f"  {idx}: {name}\n"
+        
+        yaml_content += """
+# Additional heads (wire, node detection) use separate configs
+"""
+        
+        with open(output_path / "dataset.yaml", 'w') as f:
+            f.write(yaml_content)
+    
+    def _create_difficulty_manifest(
+        self,
+        samples: List[TrainingDataSample],
+        output_path: Path
+    ):
+        """Create difficulty manifest for curriculum learning"""
+        
+        manifest = {
+            "version": "1.0",
+            "description": "Difficulty scores for curriculum learning with EMA",
+            "stages": {
+                1: {"name": "easiest", "threshold": 0.2, "samples": []},
+                2: {"name": "easy", "threshold": 0.4, "samples": []},
+                3: {"name": "medium", "threshold": 0.6, "samples": []},
+                4: {"name": "hard", "threshold": 0.8, "samples": []},
+                5: {"name": "hardest", "threshold": 1.0, "samples": []}
+            },
+            "samples": []
+        }
+        
+        for sample in samples:
+            sample_entry = {
+                "sample_id": sample.sample_id,
+                "image_path": sample.image_path,
+                "needs_review": sample.needs_review
+            }
+            
+            if sample.difficulty_scores:
+                sample_entry.update({
+                    "overall_difficulty": sample.difficulty_scores.overall_difficulty,
+                    "component_difficulty": sample.difficulty_scores.component_difficulty,
+                    "wire_difficulty": sample.difficulty_scores.wire_difficulty,
+                    "node_difficulty": sample.difficulty_scores.node_difficulty,
+                    "curriculum_stage": sample.difficulty_scores.curriculum_stage,
+                    "ema_loss_component": sample.difficulty_scores.ema_loss_component,
+                    "ema_loss_wire": sample.difficulty_scores.ema_loss_wire,
+                    "ema_loss_node": sample.difficulty_scores.ema_loss_node
+                })
+                
+                stage = sample.difficulty_scores.curriculum_stage
+                manifest["stages"][stage]["samples"].append(sample.sample_id)
+            else:
+                sample_entry["curriculum_stage"] = 3  # Default to medium
+                manifest["stages"][3]["samples"].append(sample.sample_id)
+            
+            manifest["samples"].append(sample_entry)
+        
+        with open(output_path / "difficulty_manifest.json", 'w') as f:
+            json.dump(manifest, f, indent=2)
+    
+    def export_coco(
+        self,
+        samples: List[TrainingDataSample],
+        output_dir: str,
+        min_quality: str = "LOW_CONFIDENCE"
+    ) -> ExportStats:
+        """
+        Export samples to COCO format for multi-task training.
+        
+        Args:
+            samples: List of training samples
+            output_dir: Output directory
+            min_quality: Minimum quality tier
+        
+        Returns:
+            ExportStats
+        """
+        
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        
+        stats = ExportStats()
+        
+        # Build COCO structure
+        coco_data = {
+            "info": {
+                "description": "Circuit Schematic Dataset - Agent Refined",
+                "version": "2.0",
+                "year": 2024,
+                "contributor": "Agents V2 Pipeline"
+            },
+            "licenses": [],
+            "images": [],
+            "annotations": [],
+            "categories": []
+        }
+        
+        # Add categories
+        for name, idx in self.config.component_classes.items():
+            coco_data["categories"].append({
+                "id": idx,
+                "name": name,
+                "supercategory": "component"
+            })
+        
+        # Quality filter
+        quality_order = ["FAILED", "LOW_CONFIDENCE", "CONFIDENT", "VERIFIED"]
+        min_quality_idx = quality_order.index(min_quality)
+        
+        annotation_id = 0
+        
+        for image_id, sample in enumerate(samples):
+            # Quality check
+            sample_quality_idx = quality_order.index(sample.quality_tier) if sample.quality_tier in quality_order else 0
+            if sample_quality_idx < min_quality_idx:
+                stats.skipped_samples += 1
+                continue
+            
+            stats.exported_samples += 1
+            
+            # Add image entry
+            coco_data["images"].append({
+                "id": image_id,
+                "file_name": sample.image_path,
+                "width": sample.image_width,
+                "height": sample.image_height,
+                "difficulty": sample.difficulty_scores.overall_difficulty if sample.difficulty_scores else 0.5,
+                "curriculum_stage": sample.difficulty_scores.curriculum_stage if sample.difficulty_scores else 3,
+                "needs_review": sample.needs_review
+            })
+            
+            # Add annotations
+            for ann in sample.component_annotations:
+                x = (ann.x_center - ann.width / 2) * sample.image_width
+                y = (ann.y_center - ann.height / 2) * sample.image_height
+                w = ann.width * sample.image_width
+                h = ann.height * sample.image_height
+                
+                coco_data["annotations"].append({
+                    "id": annotation_id,
+                    "image_id": image_id,
+                    "category_id": ann.class_id,
+                    "bbox": [x, y, w, h],
+                    "area": w * h,
+                    "iscrowd": 0,
+                    "attributes": {
+                        "orientation": ann.orientation,
+                        "source": ann.source,
+                        "confidence": ann.confidence,
+                        "detection_difficulty": ann.detection_difficulty
+                    }
+                })
+                annotation_id += 1
+                stats.total_components += 1
+        
+        stats.total_samples = len(samples)
+        
+        # Save COCO JSON
+        with open(output_path / "annotations.json", 'w') as f:
+            json.dump(coco_data, f, indent=2)
+        
+        return stats
+    
+    def export_multihead(
+        self,
+        samples: List[TrainingDataSample],
+        output_dir: str
+    ) -> ExportStats:
+        """
+        Export data for multi-head YOLOv11m training.
+        
+        Creates separate annotation files for each head:
+        - components.txt: Component bounding boxes
+        - wires.txt: Wire segment endpoints
+        - nodes.txt: Node/junction points
+        - terminals.txt: Terminal keypoints
+        
+        Args:
+            samples: Training samples
+            output_dir: Output directory
+        
+        Returns:
+            ExportStats
+        """
+        
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        
+        stats = ExportStats()
+        
+        for sample in samples:
+            if sample.quality_tier == "FAILED":
+                stats.skipped_samples += 1
+                continue
+            
+            sample_name = Path(sample.image_path).stem
+            
+            # Component annotations (standard YOLO format)
+            comp_path = output_path / "components" / f"{sample_name}.txt"
+            comp_path.parent.mkdir(parents=True, exist_ok=True)
+            
+            with open(comp_path, 'w') as f:
+                for ann in sample.component_annotations:
+                    f.write(ann.to_yolo_line() + "\n")
+            stats.total_components += len(sample.component_annotations)
+            
+            # Wire annotations (line segment format)
+            wire_path = output_path / "wires" / f"{sample_name}.txt"
+            wire_path.parent.mkdir(parents=True, exist_ok=True)
+            
+            with open(wire_path, 'w') as f:
+                for wire_ann in sample.wire_annotations:
+                    for seg in wire_ann.segments:
+                        # Format: class_id x1 y1 x2 y2
+                        x1, y1, x2, y2 = seg.to_normalized(
+                            sample.image_width, sample.image_height
+                        )
+                        class_id = self.config.wire_classes.get(seg.segment_type, 0)
+                        f.write(f"{class_id} {x1:.6f} {y1:.6f} {x2:.6f} {y2:.6f}\n")
+            stats.total_wires += len(sample.wire_annotations)
+            
+            # Node annotations (keypoint format)
+            node_path = output_path / "nodes" / f"{sample_name}.txt"
+            node_path.parent.mkdir(parents=True, exist_ok=True)
+            
+            with open(node_path, 'w') as f:
+                for node_ann in sample.node_annotations:
+                    # Format: class_id x y visibility
+                    class_id = self.config.node_classes.get(node_ann.node_type, 0)
+                    f.write(f"{class_id} {node_ann.x:.6f} {node_ann.y:.6f} 2\n")  # 2 = visible
+            stats.total_nodes += len(sample.node_annotations)
+            
+            # Terminal annotations (keypoint format with parent component)
+            term_path = output_path / "terminals" / f"{sample_name}.txt"
+            term_path.parent.mkdir(parents=True, exist_ok=True)
+            
+            with open(term_path, 'w') as f:
+                for term_ann in sample.terminal_annotations:
+                    # Format: class_id x y visibility component_id terminal_name
+                    f.write(f"{term_ann.class_id} {term_ann.x:.6f} {term_ann.y:.6f} 2 "
+                           f"{term_ann.component_id} {term_ann.terminal_name}\n")
+            
+            stats.exported_samples += 1
+            
+            if sample.needs_review:
+                stats.samples_needing_review += 1
+            
+            if sample.difficulty_scores:
+                stage = sample.difficulty_scores.curriculum_stage
+                stats.samples_by_stage[stage] = stats.samples_by_stage.get(stage, 0) + 1
+        
+        stats.total_samples = len(samples)
+        
+        # Create config file for multi-head training
+        self._create_multihead_config(output_path)
+        
+        return stats
+    
+    def _create_multihead_config(self, output_path: Path):
+        """Create configuration for multi-head YOLOv11m training"""
+        
+        config = {
+            "model": "yolov11m",
+            "heads": {
+                "component_detection": {
+                    "type": "detection",
+                    "annotations_dir": "components",
+                    "classes": self.config.component_classes,
+                    "loss_weight": 1.0
+                },
+                "wire_detection": {
+                    "type": "line_segment",
+                    "annotations_dir": "wires",
+                    "classes": self.config.wire_classes,
+                    "loss_weight": 0.8
+                },
+                "node_detection": {
+                    "type": "keypoint",
+                    "annotations_dir": "nodes",
+                    "classes": self.config.node_classes,
+                    "loss_weight": 0.6
+                },
+                "terminal_detection": {
+                    "type": "keypoint",
+                    "annotations_dir": "terminals",
+                    "loss_weight": 0.5
+                }
+            },
+            "curriculum_learning": {
+                "enabled": True,
+                "ema_decay": 0.9,
+                "difficulty_manifest": "difficulty_manifest.json",
+                "stage_schedule": {
+                    "stage_1_epochs": 5,
+                    "stage_2_epochs": 10,
+                    "stage_3_epochs": 15,
+                    "stage_4_epochs": 20,
+                    "stage_5_epochs": 25
+                }
+            }
+        }
+        
+        with open(output_path / "multihead_config.json", 'w') as f:
+            json.dump(config, f, indent=2)
+

--- a/agents_v2/workflow.py
+++ b/agents_v2/workflow.py
@@ -1,0 +1,706 @@
+"""
+Refinement Pipeline Workflow
+
+Orchestrates the multi-agent pipeline for circuit schematic analysis:
+1. Component Refinement (validate YOLO detections)
+2. Connectivity Refinement (validate Hough lines)
+3. Netlist Generation (create SPICE)
+4. LLM-as-Judge (validate)
+"""
+
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict, Any, Optional, Tuple
+from PIL import Image
+import hashlib
+
+from .agents.component_agent import ComponentRefinementAgent
+from .agents.connectivity_agent import ConnectivityRefinementAgent
+from .agents.netlist_agent import NetlistGenerationAgent
+from .agents.judge_agent import LLMJudge
+from .agents.base_agent import AgentContext
+
+from .models.output import PipelineOutput, StageResult, RawCVOutput, NetlistOutput
+from .models.components import ComponentInfo
+from .models.wires import WireInfo
+from .models.nodes import NodeInfo
+from .models.difficulty import DifficultyScores
+from .models.training_data import TrainingDataSample
+
+from .config import PipelineConfig
+
+
+class RefinementPipeline:
+    """Main pipeline orchestrator"""
+    
+    def __init__(self, config: Optional[PipelineConfig] = None, output_subdir: Optional[str] = None):
+        self.config = config or PipelineConfig()
+        
+        # Output directories
+        self.output_dir = Path(self.config.output_dir)
+        
+        # Use provided subdir or default to agents/
+        if output_subdir:
+            self.agents_dir = Path(output_subdir)
+        else:
+            self.agents_dir = self.output_dir / "agents"
+        
+        self.training_dir = Path(self.config.training_data_dir)
+        
+        # Create directories
+        self.agents_dir.mkdir(parents=True, exist_ok=True)
+        self.training_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Initialize agents
+        self.agent1 = ComponentRefinementAgent(
+            model=self.config.models.agent1_model,
+            config=self.config
+        )
+        
+        self.agent2 = ConnectivityRefinementAgent(
+            model=self.config.models.agent2_model,
+            config=self.config
+        )
+        
+        self.agent3 = NetlistGenerationAgent(
+            model=self.config.models.agent3_model,
+            config=self.config
+        )
+        
+        self.judge = LLMJudge(
+            model=self.config.models.judge_model,
+            config=self.config
+        )
+    
+    def run(
+        self,
+        image_path: str,
+        yolo_detections: List[Dict],
+        hough_lines: List[Dict],
+        junction_candidates: List[Dict],
+        original_image: Optional[Image.Image] = None,
+        labeled_image: Optional[Image.Image] = None
+    ) -> PipelineOutput:
+        """Run the complete refinement pipeline"""
+        
+        start_time = datetime.now()
+        
+        # Get image dimensions
+        if original_image:
+            img_width, img_height = original_image.size
+        else:
+            img = Image.open(image_path)
+            img_width, img_height = img.size
+        
+        # Initialize output
+        output = PipelineOutput(image_path=image_path)
+        
+        # Store raw CV output
+        output.raw_cv_output = RawCVOutput(
+            yolo_detections=yolo_detections,
+            hough_lines=hough_lines,
+            junction_candidates=junction_candidates,
+            image_width=img_width,
+            image_height=img_height,
+            image_hash=self._compute_image_hash(original_image) if original_image else ""
+        )
+        
+        print(f"\n{'='*70}")
+        print(f"  REFINEMENT PIPELINE v2.0")
+        print(f"  Image: {image_path}")
+        print(f"  Timestamp: {output.timestamp}")
+        print(f"{'='*70}")
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # STAGE 1: Component Refinement
+        # ═══════════════════════════════════════════════════════════════════
+        
+        print(f"\n{'─'*70}")
+        print(f"  STAGE 1: Component Refinement ({self.config.models.agent1_model})")
+        print(f"{'─'*70}")
+        
+        agent1_input = {
+            "yolo_detections": yolo_detections,
+            "image_size": {"width": img_width, "height": img_height}
+        }
+        
+        agent1_output, agent1_result = self.agent1.run(
+            input_data=agent1_input
+        )
+        
+        output.set_stage_result("component_refinement", agent1_result)
+        
+        # Extract components
+        components = agent1_output.get("components", [])
+        corrected = agent1_output.get("corrected", [])
+        agent_added = agent1_output.get("agent_added", [])
+        output.components = components
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # STAGE 2: Connectivity Refinement
+        # ═══════════════════════════════════════════════════════════════════
+        
+        print(f"\n{'─'*70}")
+        print(f"  STAGE 2: Connectivity Refinement ({self.config.models.agent2_model})")
+        if not agent1_result.passed:
+            print(f"  ⚠ Upstream needs review (confidence: {agent1_result.final_score:.2f})")
+        print(f"{'─'*70}")
+        
+        agent2_input = {
+            "hough_lines": hough_lines,
+            "components": components,
+            "image_size": {"width": img_width, "height": img_height}
+        }
+        
+        agent2_output, agent2_result = self.agent2.run(
+            input_data=agent2_input
+        )
+        
+        output.set_stage_result("connectivity_refinement", agent2_result)
+        
+        # Extract wires and nodes
+        wires = agent2_output.get("wires", [])
+        nodes = agent2_output.get("nodes", [])
+        output.wires = wires
+        output.nodes = nodes
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # STAGE 3: Netlist Generation + Judge Validation Loop
+        # ═══════════════════════════════════════════════════════════════════
+
+        print(f"\n{'─'*70}")
+        print(f"  STAGE 3: Netlist Generation ({self.config.models.agent3_model})")
+        if not agent2_result.passed:
+            print(f"  ⚠ Upstream needs review (confidence: {agent2_result.final_score:.2f})")
+        print(f"{'─'*70}")
+
+        agent3_input = {
+            "components": components,
+            "wires": wires,
+            "nodes": nodes,
+            "image_size": {"width": img_width, "height": img_height}
+        }
+
+        # Initial Agent 3 run
+        agent3_output, agent3_result = self.agent3.run(
+            input_data=agent3_input
+        )
+
+        output.set_stage_result("netlist_generation", agent3_result)
+        output.netlist = self.agent3.get_netlist_output()
+
+        # ═══════════════════════════════════════════════════════════════════
+        # STAGE 4: LLM-as-Judge with Agent 3 Retry Loop
+        # ═══════════════════════════════════════════════════════════════════
+
+        print(f"\n{'─'*70}")
+        print(f"  STAGE 4: LLM-as-Judge ({self.config.models.judge_model}) [MANDATORY]")
+        print(f"{'─'*70}")
+
+        judge_total_iterations = 0
+        best_judge_result = None
+        best_judge_score = 0.0
+
+        max_judge_retries = self.config.iterations.judge_max_retries
+
+        for judge_attempt in range(1, max_judge_retries + 2):  # +2: initial + max_retries
+            judge_total_iterations = judge_attempt
+
+            # Build topology for judge
+            netlist_str = output.netlist.spice_code if output.netlist else ""
+
+            if judge_attempt == 1:
+                print(f"\n  Initial Judge Evaluation")
+            else:
+                print(f"\n  Judge Retry {judge_attempt - 1}/{max_judge_retries}")
+
+            judge_result = self.judge.judge(
+                topology_components=components,
+                topology_nodes=nodes,
+                spice_code=netlist_str,
+                retry_on_fail=True,
+                simulation_logs=sim_logs,
+                simulation_success=sim_success,
+                image=original_image,
+                corrected=corrected,
+                agent_added=agent_added,
+            )
+
+            print(f"  Verdict: {judge_result.get('verdict')}")
+            print(f"  Confidence: {judge_result.get('confidence', 0):.2f}")
+            if judge_result.get("issues"):
+                print(f"  Issues ({len(judge_result.get('issues', []))}): {judge_result.get('issues')[:3]}")
+
+            # Track best judge result
+            current_score = judge_result.get("confidence", 0.0)
+            if current_score > best_judge_score:
+                best_judge_score = current_score
+                best_judge_result = judge_result
+
+            # Check if passed
+            if self.judge.is_pass(judge_result):
+                print(f"  ✓ PASSED - Judge validation successful")
+                best_judge_result = judge_result  # Use the passing result
+                break
+
+            # If we've exhausted retries, stop
+            if judge_attempt >= max_judge_retries + 1:
+                print(f"  ✗ FAILED - Exhausted {max_judge_retries} judge retries")
+                break
+
+            # ═══════════════════════════════════════════════════════════
+            # Get feedback for Agent 3 retry
+            # ═══════════════════════════════════════════════════════════
+
+            print(f"\n  Preparing feedback for Agent 3 retry...")
+            feedback = self.judge.get_feedback_for_retry(judge_result)
+
+            fb_agent1 = str(feedback.get("feedback_for_agent1", ""))
+            fb_agent2 = str(feedback.get("feedback_for_agent2", ""))
+
+            if fb_agent1:
+                print(f"  Feedback for Agent 1: {fb_agent1[:120]}...")
+            if fb_agent2:
+                print(f"  Feedback for Agent 2: {fb_agent2[:120]}...")
+
+            # ── Re-run Agent 1 only if judge has actionable feedback for it ──
+            # Positive-only phrases that indicate no real issue for Agent 1
+            _agent1_ok_phrases = [
+                "all correct", "all good", "no issues", "correctly identified",
+                "looks correct", "no changes needed", "nothing to change",
+                "well identified", "accurate", "no corrections needed",
+            ]
+            fb_agent1_lower = fb_agent1.lower()
+            agent1_needs_retry = bool(fb_agent1) and not any(
+                phrase in fb_agent1_lower for phrase in _agent1_ok_phrases
+            )
+
+            if agent1_needs_retry:
+                print(f"\n{'─'*70}")
+                print(f"  AGENT 1 RETRY (revision {revision + 1}, with judge feedback)")
+                print(f"{'─'*70}")
+
+                # Reset Agent 1 state
+                self.agent1.iteration_history = []
+                self.agent1.best_output = None
+                self.agent1.best_score = 0.0
+                self.agent1.best_iteration = 0
+
+                agent1_retry_input = {
+                    "yolo_detections": yolo_detections,
+                    "image_size": {"width": img_width, "height": img_height},
+                    "judge_feedback": fb_agent1,
+                }
+
+                agent1_output, agent1_result = self.agent1.run(
+                    input_data=agent1_retry_input,
+                    images=agent1_images if agent1_images else None,
+                )
+
+                output.set_stage_result("component_refinement", agent1_result)
+
+                # Update components from retry
+                components = agent1_output.get("components", [])
+                corrected = agent1_output.get("corrected", [])
+                agent_added = agent1_output.get("agent_added", [])
+                output.components = components
+
+                revision_record.agent1_ran = True
+                revision_record.agent1_score = agent1_result.final_score
+            else:
+                print(f"  ↷ Agent 1 skipped — judge has no actionable feedback for component detection")
+
+            # Store feedback for Agent 2 to use in next revision's Agent 2 run
+            judge_feedback_for_agent2 = {
+                "feedback_for_agent2": fb_agent2,
+                "errors": feedback.get("errors", []),
+                "confidence": judge_result.get("confidence", 0.0),
+                "component_issues": [
+                    f"{k}: {v.get('notes', '')}"
+                    for k, v in judge_result.get('component_mapping', {}).items()
+                    if isinstance(v, dict) and v.get('status') not in ['MATCH', 'OK', 'IMPLICIT']
+                ],
+                "node_issues": [
+                    f"{k}: {v.get('status', 'mismatch')}"
+                    for k, v in judge_result.get('node_mapping', {}).items()
+                    if isinstance(v, dict) and v.get('status') not in ['MATCH', 'OK']
+                ]
+            }
+
+            agent3_output, agent3_result = self.agent3.run(
+                input_data=agent3_retry_input
+            )
+
+            # Update netlist with new output
+            output.netlist = self.agent3.get_netlist_output()
+
+            # Merge iteration history (keep both initial + retry iterations)
+            output.stage_results["netlist_generation"].iteration_history.extend(
+                agent3_result.iteration_history
+            )
+            output.stage_results["netlist_generation"].iterations = len(
+                output.stage_results["netlist_generation"].iteration_history
+            )
+            output.stage_results["netlist_generation"].final_metrics = agent3_result.final_metrics
+            output.stage_results["netlist_generation"].final_score = agent3_result.final_score
+            output.stage_results["netlist_generation"].passed = agent3_result.passed
+
+        # ═══════════════════════════════════════════════════════════════════
+        # Finalize Judge Results
+        # ═══════════════════════════════════════════════════════════════════
+
+        judge_stage = StageResult(
+            stage_name="cross_validation",
+            model_used=self.config.models.judge_model,
+            iterations=judge_total_iterations,
+            final_score=best_judge_result.get("confidence", 0.0),
+            passed=self.judge.is_pass(best_judge_result)
+        )
+
+        if not judge_stage.passed:
+            judge_stage.needs_review = True
+            judge_stage.review_reasons = best_judge_result.get("issues", [])
+
+        output.set_stage_result("cross_validation", judge_stage)
+
+        print(f"\n{'─'*70}")
+        print(f"  JUDGE FINAL RESULT")
+        print(f"  Verdict: {best_judge_result.get('verdict')}")
+        print(f"  Confidence: {best_judge_result.get('confidence', 0):.2f}")
+        print(f"  Total Judge Iterations: {judge_total_iterations}")
+        print(f"{'─'*70}")
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # COMPUTE FINAL STATUS
+        # ═══════════════════════════════════════════════════════════════════
+        
+        output.overall_confidence = (
+            agent1_result.final_score * 0.25 +
+            agent2_result.final_score * 0.25 +
+            agent3_result.final_score * 0.25 +
+            judge_result.get("confidence", 0.0) * 0.25
+        )
+        
+        output.compute_overall_status()
+        
+        # Timing
+        output.total_time = (datetime.now() - start_time).total_seconds()
+        output.total_llm_calls = (
+            len(self.agent1.iteration_history) + 
+            len(self.agent2.iteration_history) + 
+            len(self.agent3.iteration_history) + 1  # +1 for judge
+        )
+        output.total_tokens = (
+            self.agent1.total_tokens +
+            self.agent2.total_tokens +
+            self.agent3.total_tokens +
+            self.judge.total_tokens
+        )
+        
+        # Print summary
+        self._print_summary(output)
+        
+        # Build training sample
+        training_sample = self._build_training_sample(output)
+        
+        # Save outputs
+        self._save_outputs(output, training_sample)
+        
+        return output
+    
+    def _compute_image_hash(self, image: Image.Image) -> str:
+        if image is None:
+            return ""
+        return hashlib.md5(image.tobytes()).hexdigest()[:16]
+    
+    def _build_topology_string(
+        self, 
+        components: List[Any], 
+        wires: List[Any], 
+        nodes: List[Any]
+    ) -> str:
+        """Build topology description for judge"""
+        lines = ["TOPOLOGY:"]
+        lines.append("\nCOMPONENTS:")
+        
+        for comp in components:
+            if hasattr(comp, 'id'):
+                cid, ctype = comp.id, comp.type
+                terms = [t.name for t in comp.terminals] if comp.terminals else []
+            else:
+                cid = comp.get('id', '?')
+                ctype = comp.get('type', '?')
+                terms = [t.get('name', '?') for t in comp.get('terminals', [])]
+            
+            lines.append(f"  {cid}: {ctype} (terminals: {', '.join(terms)})")
+        
+        lines.append("\nNODES:")
+        for node in nodes:
+            nid = node.id if hasattr(node, 'id') else node.get('id', '?')
+            ntype = node.type if hasattr(node, 'type') else node.get('type', '?')
+            lines.append(f"  {nid}: {ntype}")
+        
+        return "\n".join(lines)
+    
+    def _print_summary(self, output: PipelineOutput):
+        """Print pipeline summary"""
+        print(f"\n{'='*70}")
+        print(f"  PIPELINE SUMMARY")
+        print(f"{'='*70}")
+        
+        print(f"\n  Status: {output.overall_status}")
+        print(f"  Quality Tier: {output.quality_tier}")
+        print(f"  Overall Confidence: {output.overall_confidence:.3f}")
+        print(f"  Needs Review: {output.needs_review}")
+        
+        if output.review_reasons:
+            print(f"\n  Review Reasons:")
+            for reason in output.review_reasons[:5]:
+                print(f"    • {reason[:80]}")
+        
+        print(f"\n  Stage Results:")
+        for name, result in output.stage_results.items():
+            status = "✓" if result.passed else "⚠"
+            print(f"    {status} {name}: {result.final_score:.3f} ({result.iterations} iterations)")
+        
+        print(f"\n  Performance:")
+        print(f"    Total Time: {output.total_time:.1f}s")
+        print(f"    LLM Calls: {output.total_llm_calls}")
+        print(f"    Total Tokens: {output.total_tokens}")
+        
+        print(f"\n{'='*70}")
+    
+    def _build_training_sample(self, output: PipelineOutput) -> TrainingDataSample:
+        """Build training data sample"""
+        image_stem = Path(output.image_path).stem
+        
+        sample = TrainingDataSample(
+            sample_id=f"{image_stem}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
+            image_path=output.image_path
+        )
+        
+        # Set status from output
+        sample.pipeline_status = output.overall_status
+        sample.quality_tier = output.quality_tier
+        sample.overall_confidence = output.overall_confidence
+        
+        # Add difficulty scores
+        sample.difficulty_scores = DifficultyScores()
+        
+        return sample
+    
+    def _save_outputs(self, output: PipelineOutput, training_sample: TrainingDataSample):
+        """Save all outputs to files"""
+        
+        image_stem = Path(output.image_path).stem
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # AGENTS JSON
+        # ═══════════════════════════════════════════════════════════════════
+        
+        agents_output = {
+            "image_path": output.image_path,
+            "timestamp": output.timestamp,
+            "overall_status": output.overall_status,
+            "overall_confidence": output.overall_confidence,
+            "quality_tier": output.quality_tier,
+            "needs_review": output.needs_review,
+            
+            "stage_results": {
+                name: {
+                    "passed": r.passed,
+                    "score": r.final_score,
+                    "iterations": r.iterations,
+                    "model": r.model_used
+                }
+                for name, r in output.stage_results.items()
+            },
+            
+            "components": [c.to_dict() if hasattr(c, 'to_dict') else c for c in output.components],
+            "wires": [w.to_dict() if hasattr(w, 'to_dict') else w for w in output.wires],
+            "nodes": [n.to_dict() if hasattr(n, 'to_dict') else n for n in output.nodes],
+            
+            "performance": {
+                "total_time": output.total_time,
+                "llm_calls": output.total_llm_calls,
+                "tokens": output.total_tokens
+            }
+        }
+        
+        agents_json_path = self.agents_dir / f"{image_stem}_agents.json"
+        with open(agents_json_path, 'w') as f:
+            json.dump(agents_output, f, indent=2)
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # NETLIST
+        # ═══════════════════════════════════════════════════════════════════
+        
+        if output.netlist and output.netlist.spice_code:
+            spice_path = self.agents_dir / f"{image_stem}.sp"
+            with open(spice_path, 'w') as f:
+                f.write(output.netlist.spice_code)
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # SIMULATION LOGS
+        # ═══════════════════════════════════════════════════════════════════
+        
+        if output.netlist and output.netlist.simulation_logs:
+            sim_log_path = self.agents_dir / f"{image_stem}_simulation.log"
+            with open(sim_log_path, 'w') as f:
+                f.write(f"# Simulation Log for {image_stem}\n")
+                f.write(f"# Successful: {output.netlist.simulation_successful}\n\n")
+                f.write(output.netlist.simulation_logs)
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # CIRCUIT CAPTION (semantic description)
+        # ═══════════════════════════════════════════════════════════════════
+        
+        caption = self._generate_caption(output)
+        caption_path = self.agents_dir / f"{image_stem}_caption.txt"
+        with open(caption_path, 'w') as f:
+            f.write(caption)
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # LLM FLOW LOG
+        # ═══════════════════════════════════════════════════════════════════
+        
+        flow_log = self._generate_flow_log(output, image_stem)
+        flow_path = self.agents_dir / f"{image_stem}_llm_flow.md"
+        with open(flow_path, 'w') as f:
+            f.write(flow_log)
+        
+        # ═══════════════════════════════════════════════════════════════════
+        # TRAINING DATA
+        # ═══════════════════════════════════════════════════════════════════
+        
+        training_path = self.training_dir / f"{image_stem}_training.json"
+        with open(training_path, 'w') as f:
+            json.dump(training_sample.to_dict(), f, indent=2)
+        
+        print(f"\n  📁 Outputs saved to: {self.agents_dir}")
+        print(f"     - {image_stem}.sp (netlist)")
+        print(f"     - {image_stem}_simulation.log")
+        print(f"     - {image_stem}_caption.txt")
+        print(f"     - {image_stem}_llm_flow.md")
+        print(f"     - {image_stem}_agents.json")
+    
+    def _generate_caption(self, output: PipelineOutput) -> str:
+        """Generate a high-level circuit description"""
+        
+        # Build component list for LLM
+        comp_list = []
+        comp_counts = {}
+        for comp in output.components:
+            ctype = comp.type if hasattr(comp, 'type') else comp.get('type', 'Unknown')
+            cid = comp.id if hasattr(comp, 'id') else comp.get('id', '?')
+            comp_list.append(f"{cid}: {ctype}")
+            comp_counts[ctype] = comp_counts.get(ctype, 0) + 1
+        
+        # Get netlist
+        netlist = output.netlist.spice_code if output.netlist else ""
+        
+        # Use LLM to generate circuit description
+        try:
+            from openai import OpenAI
+            client = OpenAI()
+            
+            prompt = f"""Analyze this circuit and provide:
+1. Circuit name/type (e.g., "Current Mirror", "Differential Amplifier", "Voltage Divider")
+2. Brief description of how it works (2-3 sentences)
+3. Key characteristics
+
+Components: {', '.join(comp_list)}
+
+Netlist:
+{netlist[:800] if netlist else 'N/A'}
+
+Format your response as:
+CIRCUIT: [name]
+DESCRIPTION: [how it works]
+TOPOLOGY: [input] -> [processing stages] -> [output]
+"""
+
+            response = client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=300,
+                temperature=0.3
+            )
+            
+            return response.choices[0].message.content.strip()
+            
+        except Exception as e:
+            # Fallback
+            comp_str = ", ".join(f"{v} {k}{'s' if v > 1 else ''}" for k, v in comp_counts.items())
+            return f"Analog circuit with {comp_str}"
+    
+    def _generate_flow_log(self, output: PipelineOutput, image_stem: str) -> str:
+        """Generate LLM flow log in markdown"""
+        
+        lines = []
+        lines.append(f"# Circuit Analysis: {image_stem}")
+        lines.append(f"")
+        lines.append(f"**Status:** {output.overall_status}")
+        lines.append(f"**Confidence:** {output.overall_confidence:.1%}")
+        lines.append(f"")
+        
+        # Components table
+        lines.append(f"## Components ({len(output.components)})")
+        lines.append(f"")
+        lines.append(f"| ID | Type | Source | Confidence |")
+        lines.append(f"|---|---|---|---|")
+        for comp in output.components:
+            cid = comp.id if hasattr(comp, 'id') else comp.get('id', '?')
+            ctype = comp.type if hasattr(comp, 'type') else comp.get('type', '?')
+            source = comp.source if hasattr(comp, 'source') else comp.get('source', '?')
+            conf = comp.confidence if hasattr(comp, 'confidence') else comp.get('confidence', 0)
+            lines.append(f"| {cid} | {ctype} | {source} | {conf:.2f} |")
+        lines.append(f"")
+        
+        # Wires summary
+        lines.append(f"## Wires ({len(output.wires)})")
+        lines.append(f"")
+        
+        # Netlist
+        if output.netlist and output.netlist.spice_code:
+            lines.append(f"## Generated Netlist")
+            lines.append(f"")
+            lines.append(f"```spice")
+            lines.append(output.netlist.spice_code)
+            lines.append(f"```")
+            lines.append(f"")
+            sim_status = "✓ PASSED" if output.netlist.simulation_successful else "✗ FAILED"
+            lines.append(f"**Simulation:** {sim_status}")
+        
+        # Stage results
+        lines.append(f"")
+        lines.append(f"## Pipeline Stages")
+        lines.append(f"")
+        for name, result in output.stage_results.items():
+            status = "✓" if result.passed else "✗"
+            lines.append(f"- **{name}**: {status} (score: {result.final_score:.2f})")
+        
+        return "\n".join(lines)
+
+
+def run_pipeline(
+    image_path: str,
+    yolo_detections: List[Dict],
+    hough_lines: List[Dict],
+    junction_candidates: List[Dict],
+    config: Optional[PipelineConfig] = None,
+    output_subdir: Optional[str] = None,
+    **kwargs
+) -> PipelineOutput:
+    """Convenience function to run pipeline"""
+    
+    pipeline = RefinementPipeline(config, output_subdir=output_subdir)
+    return pipeline.run(
+        image_path=image_path,
+        yolo_detections=yolo_detections,
+        hough_lines=hough_lines,
+        junction_candidates=junction_candidates,
+        **kwargs
+    )
+


### PR DESCRIPTION
Added V2 multi-agent pipeline with ngspice simulation validation

Summary:

- Replaces the single-LLM-pass V1 netlist generation with a three-agent pipeline: Agent 1 (component validation) → Agent 2 (netlist generation with vision) → LLM-as-Judge (cross-validation with C1–C5 criteria)

- Adds ngspice simulation as an objective hard gate (C1) inside the judge — netlist must simulate successfully to pass

- Adds an outer feedback loop: on judge FAIL, free-text feedback is routed back to both agents for up to 2 revisions; Agent 1 re-run is skipped when judge feedback is positive-only

- Judge uses 5 explicit criteria (C1 simulation validity, C2 component completeness, C3 type match, C4 topological plausibility, C5 no hallucinations) with a formula-based confidence score — no LLM vibe scoring

- Agent 1 receives the labeled detection overlay + original image + component-removed image for visual grounding; Agent 2 receives the original image for connectivity inference

- All agents use OpenAI vision models with 1024px image cap and JPEG compression to control token cost

Adds --image / --batch --parallel CLI in agents_v2/run.py with per-image output directories (.sp, _simulation.log, _judge_result.json, _llm_flow.md)